### PR TITLE
add committing identity

### DIFF
--- a/update-styles/update-styles.sh
+++ b/update-styles/update-styles.sh
@@ -24,6 +24,20 @@ else
   ref="${REF:-gh-pages}"
 fi
 
+if [[ $(git config --global user.email) ]]
+then
+  echo ok > /dev/null
+else
+  git config --global user.email "team@carpentries.org"
+fi
+
+if [[ $(git config --global user.name) ]]
+then
+  echo ok > /dev/null
+else
+  git config --global user.name "Carpentries Bot"
+fi
+
 git remote add styles https://github.com/carpentries/styles.git
 git fetch -n styles ${ref}:styles-ref
 echo "::endgroup::"
@@ -57,8 +71,7 @@ then
   if [[ ${COMMIT} == 'true' ]]
   then
     echo "Adding merge commit"
-    git commit -m "[actions] Sync lesson with carpentries/styles" \
-      --author "The Carpentries Bot <team@carpentries.org>"
+    git commit -m "[actions] Sync lesson with carpentries/styles"
     git branch -D styles-ref
     git remote remove styles
   else


### PR DESCRIPTION
This adds a committing identity [because of this failed run](https://github.com/carpentries/lesson-example/runs/3416738815?check_suite_focus=true)

```
There are 18 changes upstream
  Testing merge using recursive strategy, accepting upstream changes without committing
  Committer identity unknown
  
  *** Please tell me who you are.
  
  Run
  
    git config --global user.email "you@example.com"
    git config --global user.name "Your Name"
  
  to set your account's default identity.
  Omit --global to set the identity only in this repository.
  
  fatal: empty ident name (for <runner@fv-az183-653.aixeropmy22uphdfpsuanqabdh.cx.internal.cloudapp.net>) not allowed
  Removing previously deleted files
  fatal: No pathspec was given. Which files should I remove?
  No files to remove
  Adding merge commit
  Committer identity unknown
  
  *** Please tell me who you are.
  
  Run
  
    git config --global user.email "you@example.com"
    git config --global user.name "Your Name"
  
  to set your account's default identity.
  Omit --global to set the identity only in this repository.
  
  fatal: empty ident name (for <runner@fv-az183-653.aixeropmy22uphdfpsuanqabdh.cx.internal.cloudapp.net>) not allowed
```