### PR TITLE
this will no longer fail on error, but emit a status message

### DIFF
--- a/download-workflow-artifact/action.yaml
+++ b/download-workflow-artifact/action.yaml
@@ -19,6 +19,9 @@ inputs:
     description: 'github token'
     required: true
     default: ${{ github.token }}
+outputs:
+  success:
+    description: "a boolean variable if the download was successful (true) or not (false)"
 runs:
   using: 'node12'
   main: 'index.js'

--- a/download-workflow-artifact/index.js
+++ b/download-workflow-artifact/index.js
@@ -36,16 +36,14 @@ async function run() {
       artifact_id: matchArtifact.id,
       archive_format: 'zip',
     }).catch(err => { 
-      // HTTP errors turn into a failed run --------------------------------------
       console.log(err);
-      core.setFailed(`There was a problem with the request (Status ${err.status}). See log.`);
-      process.exit(1);
+      core.setOutput("success", false);
     });
-
     fs.writeFileSync(`${dir}/${name}.zip`, Buffer.from(download.data));
+    core.setOutput("success", true);
   } else {
-    console.log(artifacts);
-    core.setFailed(`${name}.zip could not be found. Check logs.`)
+    console.log(`${artifacts}.zip could not be found`);
+    core.setOutput("success", false);
   }
 }
 


### PR DESCRIPTION
update download workflow artifacts to not fail on missing artifacts

It will emit a "success" output of false instead.