### PR TITLE
outsource renv action items to zkamvar/vise

### DIFF
--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -64,27 +64,23 @@ runs:
         shell: Rscript {0}
         run: |
           # Verify inputs ------------------------------------------------------
-          cat("::group::Verifying inputs\n")
-          in_repos <- expression(${{ inputs.repos }})
-          pd <- getParseData(parse(text = as.character(in_repos)))
-          funs <- pd$token == "SYMBOL_FUNCTION_CALL"
-          if (any(funs) && any(pd$text[funs] != "c")) {
-            stop("::error::repository settings should be an R vector. No functions other than `c()` are allowed")
-          }
+          cat("::group::Verifying inputs and setting repositories\n")
+          library(vise)
+          vise::verify_simple_vector(${{ inputs.repos }})
+          options(repos = ${{ inputs.repos }})
+          cat("done")
           cat("::endgroup::\n")
           # Setup --------------------------------------------------------------
           cat("::group::Preparing {renv}\n")
-          # load packages needed for sysreqs
+          # load packages needed for ci_sysreqs
           library(desc)
           library(remotes)
-          library(vise)
           on_linux <- Sys.info()[["sysname"]] == "Linux"
           if (on_linux)
             options(repos = c(RSPM = Sys.getenv("RSPM"), getOption("repos")))
-          options(repos = ${{ inputs.repos }})
-
           n <- 0
           the_report <- character(0)
+          cat("done")
           cat("::endgroup::\n")
 
           # Load {renv}, read lockfile, restore, hydrate, and snapshot ---------

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -74,6 +74,9 @@ runs:
           cat("::endgroup::\n")
           # Setup --------------------------------------------------------------
           cat("::group::Preparing {renv}\n")
+          # load packages needed for sysreqs
+          library(desc)
+          library(remotes)
           library(vise)
           on_linux <- Sys.info()[["sysname"]] == "Linux"
           if (on_linux)

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -78,76 +78,79 @@ runs:
           on_linux <- Sys.info()[["sysname"]] == "Linux"
           if (on_linux)
             options(repos = c(RSPM = Sys.getenv("RSPM"), getOption("repos")))
-          n <- 0
-          the_report <- character(0)
+          # n <- 0
+          # the_report <- character(0)
           cat("done")
           cat("::endgroup::\n")
 
           # Load {renv}, read lockfile, restore, hydrate, and snapshot ---------
           cat("::group::Restoring package library\n")
-          Sys.setenv("RENV_PROFILE" = "${{ inputs.profile }}")
-          lib  <- renv::paths$library()
-          lock <- renv::paths$lockfile()
-          current_lock <- asNamespace("renv")$lockfile(lock)
-          renv::load()
-          shh <- capture.output(renv::restore(library = lib, lockfile = lock))
-          cat("::endgroup::\n")
+          vise:::ci_update(profile = "${{ inputs.profile }}",
+            update = "${{ inputs.update }}",
+            repos = "${{ inputs.repos }}")
+          # Sys.setenv("RENV_PROFILE" = "${{ inputs.profile }}")
+          # lib  <- renv::paths$library()
+          # lock <- renv::paths$lockfile()
+          # current_lock <- asNamespace("renv")$lockfile(lock)
+          # renv::load()
+          # shh <- capture.output(renv::restore(library = lib, lockfile = lock))
+          # cat("::endgroup::\n")
 
-          # Detect any new packages that entered the lesson --------------------
-          cat("::group::Discovering new packages\n")
-          hydra       <- renv::hydrate(library = lib, update = FALSE)
-          new_lock    <- renv::snapshot(library = lib, lockfile = lock)
-          sneaky_pkgs <- setdiff(names(new_lock$Packages), names(current_lock$Packages))
-          if (length(sneaky_pkgs)) {
-            these <- new_lock$Packages[sneaky_pkgs]
-            pkg_info <- function(i) {
-              lead <- "- "
-              paste0(lead, i$Package, '\t[* -> ', i$Version, ']')
-            }
-            pkgs <- vapply(these, FUN = pkg_info, FUN.VALUE = character(1))
-            if (on_linux) {
-              vise::ci_sysreqs(lock, execute = TRUE)
-            }
-            n <- n + length(sneaky_pkgs)
-            the_report <- c(the_report, 
-              "# NEW ================================",
-              pkgs,
-              ""
-            )
-            cat(n, "packages found", paste(sneaky_pkgs, collapse = ", "), "\n")
-          }
-          cat("::endgroup::\n")
-          # Check for updates to packages --------------------------------------
-          should_update <- '${{ inputs.update }}' == 'true'
-          if (should_update) {
-            cat("::group::Applying Updates\n")
-            updates <- renv::update(library = lib, check = TRUE)
-            updates_needed <- !identical(updates, TRUE)
-          } else {
-            updates_needed <- FALSE
-          }
-          if (updates_needed) {
-            # apply the updates and run a snapshot if the dry run found updates
-            renv::update(library = lib)
-            renv::snapshot(lockfile = lock)
-            n <- n + length(updates$diff)
-            the_report <- c(the_report, 
-              utils::capture.output(print(updates), type = "message"))
-            cat("Updating", length(updates$diff), "packages", "\n")
-            cat("::endgroup::\n")
-          }
-          cat("::group::Cleaning the cache\n")
-          renv::clean(actions = c('package.locks', 'library.tempdirs', 'unused.packages'))
-          cat("::endgroup::\n")
-          # Construct the output -----------------------------------------------
-          # https://github.community/t/set-output-truncates-multiline-strings/16852/3?u=zkamvar
-          cat("::group::Creating the output\n")
-          the_report <- paste0(the_report, collapse = "%0A")
-          meow  <- function(...) cat(..., "\n", sep = "")
-          meow(the_report)
-          meow("::set-output name=report::", the_report)
-          meow("::set-output name=n::", n)
-          meow("::set-output name=date::", as.character(Sys.Date()))
+          # # Detect any new packages that entered the lesson --------------------
+          # cat("::group::Discovering new packages\n")
+          # hydra       <- renv::hydrate(library = lib, update = FALSE)
+          # new_lock    <- renv::snapshot(library = lib, lockfile = lock)
+          # sneaky_pkgs <- setdiff(names(new_lock$Packages), names(current_lock$Packages))
+          # if (length(sneaky_pkgs)) {
+          #   these <- new_lock$Packages[sneaky_pkgs]
+          #   pkg_info <- function(i) {
+          #     lead <- "- "
+          #     paste0(lead, i$Package, '\t[* -> ', i$Version, ']')
+          #   }
+          #   pkgs <- vapply(these, FUN = pkg_info, FUN.VALUE = character(1))
+          #   if (on_linux) {
+          #     vise::ci_sysreqs(lock, execute = TRUE)
+          #   }
+          #   n <- n + length(sneaky_pkgs)
+          #   the_report <- c(the_report, 
+          #     "# NEW ================================",
+          #     pkgs,
+          #     ""
+          #   )
+          #   cat(n, "packages found", paste(sneaky_pkgs, collapse = ", "), "\n")
+          # }
+          # cat("::endgroup::\n")
+          # # Check for updates to packages --------------------------------------
+          # should_update <- '${{ inputs.update }}' == 'true'
+          # if (should_update) {
+          #   cat("::group::Applying Updates\n")
+          #   updates <- renv::update(library = lib, check = TRUE)
+          #   updates_needed <- !identical(updates, TRUE)
+          # } else {
+          #   updates_needed <- FALSE
+          # }
+          # if (updates_needed) {
+          #   # apply the updates and run a snapshot if the dry run found updates
+          #   renv::update(library = lib)
+          #   renv::snapshot(lockfile = lock)
+          #   n <- n + length(updates$diff)
+          #   the_report <- c(the_report, 
+          #     utils::capture.output(print(updates), type = "message"))
+          #   cat("Updating", length(updates$diff), "packages", "\n")
+          #   cat("::endgroup::\n")
+          # }
+          # cat("::group::Cleaning the cache\n")
+          # renv::clean(actions = c('package.locks', 'library.tempdirs', 'unused.packages'))
+          # cat("::endgroup::\n")
+          # # Construct the output -----------------------------------------------
+          # # https://github.community/t/set-output-truncates-multiline-strings/16852/3?u=zkamvar
+          # cat("::group::Creating the output\n")
+          # the_report <- paste0(the_report, collapse = "%0A")
+          # meow  <- function(...) cat(..., "\n", sep = "")
+          # meow(the_report)
+          # meow("::set-output name=report::", the_report)
+          # meow("::set-output name=n::", n)
+          # meow("::set-output name=date::", as.character(Sys.Date()))
           cat("::endgroup::\n")
 
       - name: Don't use tar 1.30 from Rtools35 to store the cache

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -74,6 +74,7 @@ runs:
           cat("::endgroup::\n")
           # Setup --------------------------------------------------------------
           cat("::group::Preparing {renv}\n")
+          remotes::install_github("zkamvar/vise")
           on_linux <- Sys.info()[["sysname"]] == "Linux"
           if (on_linux)
             options(repos = c(RSPM = Sys.getenv("RSPM"), getOption("repos")))

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -44,44 +44,19 @@ runs:
       - name: "Setup System Dependencies"
         shell: Rscript {0}
         run: |
+          req <- function(pkg) {
+            if (!requireNamespace(pkg, quietly = TRUE)) 
+              install.packages(pkg, repos = "https://cran.rstudio.com")
+          }
           wd <- '${{ github.workspace }}'
           has_lock <- file.exists(file.path(wd, 'renv'))
           if (Sys.info()[["sysname"]] == "Linux" && has_lock) {
-            if (!requireNamespace("renv")) {
-              install.packages("renv", repos = "https://cran.rstudio.com")
-            }
-            if (!requireNamespace("pak")) {
-              install.packages("pak", repos = "https://r-lib.github.io/p/pak/stable/")
-            }
-            if (!requireNamespace("processx")) {
-              install.packages("processx")
-            }
+            req("renv")
+            req("remotes")
+            req("desc")
+            remotes::install_github("zkamvar/vise")
             Sys.setenv("RENV_PROFILE" = "lesson-requirements")
-            lock <- renv:::lockfile(renv::paths$lockfile())$data()
-            pkgs <- names(lock$Packages)
-            db <- available.packages()
-            compiled <- db[, "Package"] %in% pkgs & db[, "NeedsCompilation"] == "yes"
-            pkgs <- db[compiled, "Package", drop = TRUE]
-            ver <- tolower(system("lsb_release -irs", intern = TRUE))
-            seen <- character(0)
-            for (dep in pkgs) {
-              if (dep == "stringi") { # We have this one taken care of
-                next
-              }
-              these <- pak::pkg_system_requirements(
-                os = ver[1], os_release = ver[2], package = dep, execute = FALSE
-              )
-              these <- sub('apt-get install -y ', '', these)
-              new <- setdiff(these, seen)
-              if (length(new)) {
-                seen <- c(seen, new)
-                cmd <- paste(new, collapse = " ")
-                cmd <- paste("sudo apt-get install -y", cmd)
-                cat("Executing", cmd, "\n")
-                processx::run("sh", c("-c", cmd), stdout_callback = NULL,
-                  stderr_to_stdout = TRUE)
-              }
-            }
+            vise::ci_sysreqs(renv::paths$lockfile(), execute = TRUE)
           }
 
       - name: "Update {renv} deps and determine if a PR is needed"
@@ -103,10 +78,7 @@ runs:
           if (on_linux)
             options(repos = c(RSPM = Sys.getenv("RSPM"), getOption("repos")))
           options(repos = ${{ inputs.repos }})
-          if (!requireNamespace("renv", quietly = TRUE))
-            install.packages("renv")
-          if (!requireNamespace("jsonlite", quietly = TRUE))
-            install.packages("jsonlite")
+
           n <- 0
           the_report <- character(0)
           cat("::endgroup::\n")
@@ -116,7 +88,7 @@ runs:
           Sys.setenv("RENV_PROFILE" = "${{ inputs.profile }}")
           lib  <- renv::paths$library()
           lock <- renv::paths$lockfile()
-          current_lock <- jsonlite::read_json(lock)
+          current_lock <- vise::lockfile(lock)
           renv::load()
           shh <- capture.output(renv::restore(library = lib, lockfile = lock))
           cat("::endgroup::\n")
@@ -134,18 +106,7 @@ runs:
             }
             pkgs <- vapply(these, FUN = pkg_info, FUN.VALUE = character(1))
             if (on_linux) {
-              # We need to make sure that we have the resources for the packages
-              # we are bringing in. This _could_ be optimized, but considering
-              # this is an update step and not a production step, it can take
-              # its sweet time. 
-              if (!requireNamespace("pak", quietly = TRUE))
-                install.packages("pak")
-              ver <- tolower(system("lsb_release -irs", intern = TRUE))
-              for (pkg in these) {
-                pak::pkg_system_requirements(
-                  os = ver[1], os_release = ver[2], package = dep, execute = TRUE
-                )
-              }
+              vise::ci_sysreqs(lock, execute = TRUE)
             }
             n <- n + length(sneaky_pkgs)
             the_report <- c(the_report, 

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -88,7 +88,7 @@ runs:
           Sys.setenv("RENV_PROFILE" = "${{ inputs.profile }}")
           lib  <- renv::paths$library()
           lock <- renv::paths$lockfile()
-          current_lock <- vise::lockfile(lock)
+          current_lock <- asNamespace("renv")$lockfile(lock)
           renv::load()
           shh <- capture.output(renv::restore(library = lib, lockfile = lock))
           cat("::endgroup::\n")

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -74,7 +74,7 @@ runs:
           cat("::endgroup::\n")
           # Setup --------------------------------------------------------------
           cat("::group::Preparing {renv}\n")
-          remotes::install_github("zkamvar/vise")
+          library(vise)
           on_linux <- Sys.info()[["sysname"]] == "Linux"
           if (on_linux)
             options(repos = c(RSPM = Sys.getenv("RSPM"), getOption("repos")))

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -70,87 +70,14 @@ runs:
           options(repos = ${{ inputs.repos }})
           cat("done")
           cat("::endgroup::\n")
-          # Setup --------------------------------------------------------------
-          cat("::group::Preparing {renv}\n")
+          # Update the packages as needed --------------------------------------
+          cat("::group::Restoring package library\n")
           # load packages needed for ci_sysreqs
           library(desc)
           library(remotes)
-          on_linux <- Sys.info()[["sysname"]] == "Linux"
-          if (on_linux)
-            options(repos = c(RSPM = Sys.getenv("RSPM"), getOption("repos")))
-          # n <- 0
-          # the_report <- character(0)
-          cat("done")
-          cat("::endgroup::\n")
-
-          # Load {renv}, read lockfile, restore, hydrate, and snapshot ---------
-          cat("::group::Restoring package library\n")
           vise:::ci_update(profile = "${{ inputs.profile }}",
             update = "${{ inputs.update }}",
             repos = "${{ inputs.repos }}")
-          # Sys.setenv("RENV_PROFILE" = "${{ inputs.profile }}")
-          # lib  <- renv::paths$library()
-          # lock <- renv::paths$lockfile()
-          # current_lock <- asNamespace("renv")$lockfile(lock)
-          # renv::load()
-          # shh <- capture.output(renv::restore(library = lib, lockfile = lock))
-          # cat("::endgroup::\n")
-
-          # # Detect any new packages that entered the lesson --------------------
-          # cat("::group::Discovering new packages\n")
-          # hydra       <- renv::hydrate(library = lib, update = FALSE)
-          # new_lock    <- renv::snapshot(library = lib, lockfile = lock)
-          # sneaky_pkgs <- setdiff(names(new_lock$Packages), names(current_lock$Packages))
-          # if (length(sneaky_pkgs)) {
-          #   these <- new_lock$Packages[sneaky_pkgs]
-          #   pkg_info <- function(i) {
-          #     lead <- "- "
-          #     paste0(lead, i$Package, '\t[* -> ', i$Version, ']')
-          #   }
-          #   pkgs <- vapply(these, FUN = pkg_info, FUN.VALUE = character(1))
-          #   if (on_linux) {
-          #     vise::ci_sysreqs(lock, execute = TRUE)
-          #   }
-          #   n <- n + length(sneaky_pkgs)
-          #   the_report <- c(the_report, 
-          #     "# NEW ================================",
-          #     pkgs,
-          #     ""
-          #   )
-          #   cat(n, "packages found", paste(sneaky_pkgs, collapse = ", "), "\n")
-          # }
-          # cat("::endgroup::\n")
-          # # Check for updates to packages --------------------------------------
-          # should_update <- '${{ inputs.update }}' == 'true'
-          # if (should_update) {
-          #   cat("::group::Applying Updates\n")
-          #   updates <- renv::update(library = lib, check = TRUE)
-          #   updates_needed <- !identical(updates, TRUE)
-          # } else {
-          #   updates_needed <- FALSE
-          # }
-          # if (updates_needed) {
-          #   # apply the updates and run a snapshot if the dry run found updates
-          #   renv::update(library = lib)
-          #   renv::snapshot(lockfile = lock)
-          #   n <- n + length(updates$diff)
-          #   the_report <- c(the_report, 
-          #     utils::capture.output(print(updates), type = "message"))
-          #   cat("Updating", length(updates$diff), "packages", "\n")
-          #   cat("::endgroup::\n")
-          # }
-          # cat("::group::Cleaning the cache\n")
-          # renv::clean(actions = c('package.locks', 'library.tempdirs', 'unused.packages'))
-          # cat("::endgroup::\n")
-          # # Construct the output -----------------------------------------------
-          # # https://github.community/t/set-output-truncates-multiline-strings/16852/3?u=zkamvar
-          # cat("::group::Creating the output\n")
-          # the_report <- paste0(the_report, collapse = "%0A")
-          # meow  <- function(...) cat(..., "\n", sep = "")
-          # meow(the_report)
-          # meow("::set-output name=report::", the_report)
-          # meow("::set-output name=n::", n)
-          # meow("::set-output name=date::", as.character(Sys.Date()))
           cat("::endgroup::\n")
 
       - name: Don't use tar 1.30 from Rtools35 to store the cache


### PR DESCRIPTION
The renv actions have gotten really hairy and it's time that I package them up into something more suitable.

First up is the package updating action:

1. wrap lockfiles + remotes so that we can more quickly address dependencies on the command line. 
2. pull out update script and extract standalone functions