### PR TITLE
add patch for changes to the R Universe API

### DIFF
--- a/setup-sandpaper/action.yaml
+++ b/setup-sandpaper/action.yaml
@@ -45,7 +45,7 @@ runs:
         run: |
           sudo apt-get install -y \
            libxslt-dev \
-           $(curl https://carpentries.r-universe.dev/stats/sysdeps 2> /dev/null | jq -r '.sysdep') 2> /dev/null \
+           $(curl https://carpentries.r-universe.dev/stats/sysdeps 2> /dev/null | jq -r '.headers[0] | select(. != null)') 2> /dev/null \
           || echo "Not on Ubuntu"
 
       - name: Restore R package cache


### PR DESCRIPTION
Jeroen has added a condition in the R-universe API that notes a
difference between headers (needed to build packages) and packages
(needed for the runtime). From my conversation:

Jeroen Ooms  07:38
You need to install headers if you want to build the package from source. Once it has been compiled, you only need the ‘packages’ at run-time.

Zhian Kamvar  07:40
so I'll need both?

Jeroen Ooms  07:40
Depends on what you’re doing :slightly_smiling_face:
07:41
If you want to build/check the package from source, install the headers.
07:41
This will also automatically install the runtime, because one depends on the other.

Zhian Kamvar  07:42
gotcha. This is installing packages from source, so I'll only need the headers?
New

Jeroen Ooms  07:42
Yes that is correct



This will fix #39 
