### PR TITLE
More reliable RSPM setup

### DIFF
--- a/setup-lesson-deps/action.yaml
+++ b/setup-lesson-deps/action.yaml
@@ -26,7 +26,7 @@ runs:
             if (Sys.getenv("RSPM") == "") {
               release <- system("lsb_release -c | awk '{print $2}'", intern = TRUE)
               Sys.setenv("RSPM" = 
-                paste("https://packagemanager.rstudio.com/all/__linux__/", release, "/latest"))
+                paste0("https://packagemanager.rstudio.com/all/__linux__/", release, "/latest"))
             }
           }
           repos <- list(
@@ -71,7 +71,7 @@ runs:
             if (Sys.getenv("RSPM") == "") {
               release <- system("lsb_release -c | awk '{print $2}'", intern = TRUE)
               Sys.setenv("RSPM" = 
-                paste("https://packagemanager.rstudio.com/all/__linux__/", release, "/latest"))
+                paste0("https://packagemanager.rstudio.com/all/__linux__/", release, "/latest"))
             }
           }
           repos <- list(

--- a/setup-lesson-deps/action.yaml
+++ b/setup-lesson-deps/action.yaml
@@ -24,7 +24,8 @@ runs:
           repos <- list(
             carpentries = "https://carpentries.r-universe.dev/",
             archive     = "https://carpentries.github.io/drat/",
-            CRAN        = "https://cran.rstudio.com"
+            CRAN        = "https://cran.rstudio.com",
+            RSPM        = Sys.getenv("RSPM")
           )
           old_repos <- as.list(getOption("repos"))
           new_repos <- unlist(modifyList(old_repos, repos))
@@ -60,7 +61,8 @@ runs:
           repos <- list(
             carpentries = "https://carpentries.r-universe.dev/",
             archive     = "https://carpentries.github.io/drat/",
-            CRAN        = "https://cran.rstudio.com"
+            CRAN        = "https://cran.rstudio.com",
+            RSPM        = Sys.getenv("RSPM")
           )
           old_repos <- as.list(getOption("repos"))
           new_repos <- unlist(modifyList(old_repos, repos))

--- a/setup-lesson-deps/action.yaml
+++ b/setup-lesson-deps/action.yaml
@@ -21,11 +21,19 @@ runs:
         shell: Rscript {0}
         run: |
           cat("::group::Register Repositories\n")
+          on_linux <- Sys.info()[["sysname"]] == "Linux"
+          if (on_linux) {
+            if (Sys.getenv("RSPM") == "") {
+              release <- system("lsb_release -c | awk '{print $2}'", intern = TRUE)
+              Sys.setenv("RSPM" = 
+                paste("https://packagemanager.rstudio.com/all/__linux__/", release, "/latest"))
+            }
+          }
           repos <- list(
+            RSPM        = Sys.getenv("RSPM"),
             carpentries = "https://carpentries.r-universe.dev/",
             archive     = "https://carpentries.github.io/drat/",
-            CRAN        = "https://cran.rstudio.com",
-            RSPM        = Sys.getenv("RSPM")
+            CRAN        = "https://cran.rstudio.com"
           )
           old_repos <- as.list(getOption("repos"))
           new_repos <- unlist(modifyList(old_repos, repos))
@@ -58,11 +66,19 @@ runs:
         shell: Rscript {0}
         run: |
           cat("::group::Register Repositories\n")
+          on_linux <- Sys.info()[["sysname"]] == "Linux"
+          if (on_linux) {
+            if (Sys.getenv("RSPM") == "") {
+              release <- system("lsb_release -c | awk '{print $2}'", intern = TRUE)
+              Sys.setenv("RSPM" = 
+                paste("https://packagemanager.rstudio.com/all/__linux__/", release, "/latest"))
+            }
+          }
           repos <- list(
+            RSPM        = Sys.getenv("RSPM"),
             carpentries = "https://carpentries.r-universe.dev/",
             archive     = "https://carpentries.github.io/drat/",
-            CRAN        = "https://cran.rstudio.com",
-            RSPM        = Sys.getenv("RSPM")
+            CRAN        = "https://cran.rstudio.com"
           )
           old_repos <- as.list(getOption("repos"))
           new_repos <- unlist(modifyList(old_repos, repos))

--- a/setup-lesson-deps/action.yaml
+++ b/setup-lesson-deps/action.yaml
@@ -20,10 +20,22 @@ runs:
       - name: "Setup System Dependencies"
         shell: Rscript {0}
         run: |
+          cat("::group::Register Repositories\n")
+          repos <- list(
+            carpentries = "https://carpentries.r-universe.dev/",
+            archive     = "https://carpentries.github.io/drat/",
+            CRAN        = "https://cran.rstudio.com"
+          )
+          old_repos <- as.list(getOption("repos"))
+          new_repos <- unlist(modifyList(old_repos, repos))
+          options(pak.no_extra_messages = TRUE, repos = new_repos)
+          cat("Repositories Used")
+          print(getOption("repos"))
+          cat("::endgroup::\n")
           # Set up system dependencies
           req <- function(pkg) {
             if (!requireNamespace(pkg, quietly = TRUE)) 
-              install.packages(pkg, repos = "https://cran.rstudio.com")
+              install.packages(pkg)
           }
           wd <- '${{ github.workspace }}'
           has_lock <- file.exists(file.path(wd, 'renv'))
@@ -44,17 +56,33 @@ runs:
       - name: "Fortify Local {renv} Packages"
         shell: Rscript {0}
         run: |
+          cat("::group::Register Repositories\n")
+          repos <- list(
+            carpentries = "https://carpentries.r-universe.dev/",
+            archive     = "https://carpentries.github.io/drat/",
+            CRAN        = "https://cran.rstudio.com"
+          )
+          old_repos <- as.list(getOption("repos"))
+          new_repos <- unlist(modifyList(old_repos, repos))
+          options(pak.no_extra_messages = TRUE, repos = new_repos)
+          cat("Repositories Used")
+          print(getOption("repos"))
+          cat("::endgroup::\n")
+
           # Fortify local {renv} packages
+          cat("::group::Fortify local {renv} packages\n")
           wd <- '${{ github.workspace }}'
           req <- function(pkg) {
             if (!requireNamespace(pkg, quietly = TRUE)) 
-              install.packages(pkg, repos = "https://cran.rstudio.com")
+              install.packages(pkg)
           }
           if (file.exists("DESCRIPTION")) {
             req("remotes")
             remotes::install_deps()
           }
+          cat("::endgroup::\n")
           if (file.exists(file.path(wd, 'renv'))) {
+            cat("::group::Fortify local {renv} packages\n")
             if (file.exists("DESCRIPTION.bak")) {
               file.rename("DESCRIPTION.bak", "DESCRIPTION")
             } else {
@@ -62,10 +90,8 @@ runs:
             }
             req("renv")
             Sys.setenv("RENV_PROFILE" = "lesson-requirements")
-            if (Sys.info()[["sysname"]] == "Linux") {
-              options(repos = c(RSPM = Sys.getenv("RSPM"), getOption("repos")))
-            }
             sandpaper::manage_deps(path = wd, quiet = FALSE)
+            cat("::endgroup::\n")
           } else {
             writeLines("Package cache not used")
           }

--- a/setup-lesson-deps/action.yaml
+++ b/setup-lesson-deps/action.yaml
@@ -35,9 +35,7 @@ runs:
             archive     = "https://carpentries.github.io/drat/",
             CRAN        = "https://cran.rstudio.com"
           )
-          old_repos <- as.list(getOption("repos"))
-          new_repos <- unlist(modifyList(old_repos, repos))
-          options(pak.no_extra_messages = TRUE, repos = new_repos)
+          options(pak.no_extra_messages = TRUE, repos = repos)
           cat("Repositories Used")
           print(getOption("repos"))
           cat("::endgroup::\n")
@@ -80,9 +78,7 @@ runs:
             archive     = "https://carpentries.github.io/drat/",
             CRAN        = "https://cran.rstudio.com"
           )
-          old_repos <- as.list(getOption("repos"))
-          new_repos <- unlist(modifyList(old_repos, repos))
-          options(pak.no_extra_messages = TRUE, repos = new_repos)
+          options(pak.no_extra_messages = TRUE, repos = repos)
           cat("Repositories Used")
           print(getOption("repos"))
           cat("::endgroup::\n")

--- a/setup-sandpaper/action.yaml
+++ b/setup-sandpaper/action.yaml
@@ -18,11 +18,19 @@ runs:
       - name: Install pak and query dependencies
         run: |
           cat("::group::Register Repositories\n")
+          on_linux <- Sys.info()[["sysname"]] == "Linux"
+          if (on_linux) {
+            if (Sys.getenv("RSPM") == "") {
+              release <- system("lsb_release -c | awk '{print $2}'", intern = TRUE)
+              Sys.setenv("RSPM" = 
+                paste("https://packagemanager.rstudio.com/all/__linux__/", release, "/latest"))
+            }
+          }
           repos <- list(
+            RSPM        = Sys.getenv("RSPM"),
             carpentries = "https://carpentries.r-universe.dev/",
             archive     = "https://carpentries.github.io/drat/",
-            CRAN        = "https://cran.rstudio.com",
-            RSPM        = Sys.getenv("RSPM")
+            CRAN        = "https://cran.rstudio.com"
           )
           old_repos <- as.list(getOption("repos"))
           new_repos <- unlist(modifyList(old_repos, repos))
@@ -82,11 +90,19 @@ runs:
       - name: Install dependencies
         run: |
           cat("::group::Register Repositories\n")
+          on_linux <- Sys.info()[["sysname"]] == "Linux"
+          if (on_linux) {
+            if (Sys.getenv("RSPM") == "") {
+              release <- system("lsb_release -c | awk '{print $2}'", intern = TRUE)
+              Sys.setenv("RSPM" = 
+                paste("https://packagemanager.rstudio.com/all/__linux__/", release, "/latest"))
+            }
+          }
           repos <- list(
+            RSPM        = Sys.getenv("RSPM"),
             carpentries = "https://carpentries.r-universe.dev/",
             archive     = "https://carpentries.github.io/drat/",
-            CRAN        = "https://cran.rstudio.com",
-            RSPM        = Sys.getenv("RSPM")
+            CRAN        = "https://cran.rstudio.com"
           )
           old_repos <- as.list(getOption("repos"))
           new_repos <- unlist(modifyList(old_repos, repos))

--- a/setup-sandpaper/action.yaml
+++ b/setup-sandpaper/action.yaml
@@ -32,9 +32,7 @@ runs:
             archive     = "https://carpentries.github.io/drat/",
             CRAN        = "https://cran.rstudio.com"
           )
-          old_repos <- as.list(getOption("repos"))
-          new_repos <- unlist(modifyList(old_repos, repos))
-          options(pak.no_extra_messages = TRUE, repos = new_repos)
+          options(pak.no_extra_messages = TRUE, repos = repos)
           cat("Repositories Used")
           print(getOption("repos"))
           cat("::endgroup::\n")
@@ -104,9 +102,7 @@ runs:
             archive     = "https://carpentries.github.io/drat/",
             CRAN        = "https://cran.rstudio.com"
           )
-          old_repos <- as.list(getOption("repos"))
-          new_repos <- unlist(modifyList(old_repos, repos))
-          options(pak.no_extra_messages = TRUE, repos = new_repos)
+          options(pak.no_extra_messages = TRUE, repos = repos)
           cat("Repositories Used")
           print(getOption("repos"))
           cat("::endgroup::\n")

--- a/setup-sandpaper/action.yaml
+++ b/setup-sandpaper/action.yaml
@@ -21,7 +21,8 @@ runs:
           repos <- list(
             carpentries = "https://carpentries.r-universe.dev/",
             archive     = "https://carpentries.github.io/drat/",
-            CRAN        = "https://cran.rstudio.com"
+            CRAN        = "https://cran.rstudio.com",
+            RSPM        = Sys.getenv("RSPM")
           )
           old_repos <- as.list(getOption("repos"))
           new_repos <- unlist(modifyList(old_repos, repos))
@@ -48,7 +49,7 @@ runs:
         id: run-apt
         shell: bash
         run: |
-          sudo apt update
+          sudo apt update || exit 0
           curl https://carpentries.r-universe.dev/stats/sysdeps 2> /dev/null \
           | jq -r '.headers[0] | select(. != null)' 2> /dev/null \
           > ${{ runner.temp }}/sysdeps.txt
@@ -84,7 +85,8 @@ runs:
           repos <- list(
             carpentries = "https://carpentries.r-universe.dev/",
             archive     = "https://carpentries.github.io/drat/",
-            CRAN        = "https://cran.rstudio.com"
+            CRAN        = "https://cran.rstudio.com",
+            RSPM        = Sys.getenv("RSPM")
           )
           old_repos <- as.list(getOption("repos"))
           new_repos <- unlist(modifyList(old_repos, repos))

--- a/setup-sandpaper/action.yaml
+++ b/setup-sandpaper/action.yaml
@@ -23,7 +23,7 @@ runs:
             if (Sys.getenv("RSPM") == "") {
               release <- system("lsb_release -c | awk '{print $2}'", intern = TRUE)
               Sys.setenv("RSPM" = 
-                paste("https://packagemanager.rstudio.com/all/__linux__/", release, "/latest"))
+                paste0("https://packagemanager.rstudio.com/all/__linux__/", release, "/latest"))
             }
           }
           repos <- list(
@@ -95,7 +95,7 @@ runs:
             if (Sys.getenv("RSPM") == "") {
               release <- system("lsb_release -c | awk '{print $2}'", intern = TRUE)
               Sys.setenv("RSPM" = 
-                paste("https://packagemanager.rstudio.com/all/__linux__/", release, "/latest"))
+                paste0("https://packagemanager.rstudio.com/all/__linux__/", release, "/latest"))
             }
           }
           repos <- list(

--- a/setup-sandpaper/action.yaml
+++ b/setup-sandpaper/action.yaml
@@ -17,15 +17,20 @@ runs:
   steps:
       - name: Install pak and query dependencies
         run: |
-          cat("::group::Install remotes\n")
-          options(
-            pak.no_extra_messages = TRUE,
-            repos = c(
-              carpentries = "https://carpentries.r-universe.dev/",
-              archive     = "https://carpentries.github.io/drat/",
-              CRAN        = "https://cran.rstudio.com"
-            )
+          cat("::group::Register Repositories\n")
+          repos <- list(
+            carpentries = "https://carpentries.r-universe.dev/",
+            archive     = "https://carpentries.github.io/drat/",
+            CRAN        = "https://cran.rstudio.com"
           )
+          old_repos <- as.list(getOption("repos"))
+          new_repos <- unlist(modifyList(old_repos, repos))
+          options(pak.no_extra_messages = TRUE, repos = new_repos)
+          cat("Repositories Used")
+          print(getOption("repos"))
+          cat("::endgroup::\n")
+
+          cat("::group::Install remotes\n")
           install.packages('remotes')
           deps <- remotes::package_deps("sandpaper", dependencies = TRUE)
           saveRDS(deps, ".github/r-depends.rds")
@@ -75,22 +80,24 @@ runs:
 
       - name: Install dependencies
         run: |
+          cat("::group::Register Repositories\n")
+          repos <- list(
+            carpentries = "https://carpentries.r-universe.dev/",
+            archive     = "https://carpentries.github.io/drat/",
+            CRAN        = "https://cran.rstudio.com"
+          )
+          old_repos <- as.list(getOption("repos"))
+          new_repos <- unlist(modifyList(old_repos, repos))
+          options(pak.no_extra_messages = TRUE, repos = new_repos)
+          cat("Repositories Used")
+          print(getOption("repos"))
+          cat("::endgroup::\n")
+
           cat("::group::Install dependencies\n")
           on_linux <- Sys.info()[["sysname"]] == "Linux"
-          options(
-            pak.no_extra_messages = TRUE,
-            repos = c(
-              carpentries = "https://carpentries.r-universe.dev/",
-              archive     = "https://carpentries.github.io/drat/",
-              CRAN        = "https://cran.rstudio.com"
-            )
-          )
-          if (on_linux) {
-            options(repos = c(RSPM = Sys.getenv("RSPM"), getOption("repos")))
-          }
           library("remotes")
           pkgs <- package_deps('sandpaper', dependencies = TRUE)
-          pkgs$diff[pkgs$package == "tinkr"] <- -1
+          print(pkgs)
           update(pkgs, upgrade = "always")
           cat("::endgroup::\n")
           varnish_version <- '${{ inputs.varnish-version }}'


### PR DESCRIPTION
I've updated the package setup actions (`setup-sandpaper` and `setup-lesson-deps`) to prefer using the RSPM so that initial builds run faster. 

Some problems I've encountered with the R runner:

1. RSPM may or may not exist as a registered CRAN repository
1. RSPM may or may not be properly set as an environment variable
1. CRAN may appear before RSPM in the repository list

All of these situations cause headaches for me, so I've decided to try fixing things once and for all. 