### PR TITLE
Add Job Summary to check-valid-credentials

### DIFF
--- a/check-valid-credentials/action.yml
+++ b/check-valid-credentials/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: "Token to validate"
     required: false
     default: ''
+  repository:
+    description: "The GitHub Repository"
+    required: false
+    default: "${{ github.repository }}"
 outputs:
   wf: 
     description: "workflow authorization"

--- a/check-valid-credentials/action.yml
+++ b/check-valid-credentials/action.yml
@@ -5,10 +5,6 @@ inputs:
     description: "Token to validate"
     required: false
     default: ''
-  repository:
-    description: "The GitHub Repository"
-    required: false
-    default: "${{ github.repository }}"
 outputs:
   wf: 
     description: "workflow authorization"

--- a/check-valid-credentials/validate.sh
+++ b/check-valid-credentials/validate.sh
@@ -24,9 +24,9 @@ else
 fi
 mkdir -p ${TMP}
 
+# Set up output first because there
 TOKEN_NAME="Sandpaper%20Token%20%28${GITHUB_REPOSITORY}%29"
 TOKEN_URL="https://github.com/settings/tokens/new?scopes=repo,workflow&description=${TOKEN_NAME}"
-
 echo "## :warning: Missing Token" >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
 echo "The \`SANDPAPER_WORKFLOW\` secret is missing, invalid, or does not" \
@@ -37,7 +37,7 @@ echo "If you want to have automated pull request updates to your package cache,"
 echo "" >> $GITHUB_STEP_SUMMARY
 echo "### Steps to Generate a New Token" >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
-echo "1. :key: [Click here to generate a new token](${TOKEN_URL}) called 'Sandpaper Token (${GITHUB_REPOSITORY})' from your GitHub Account" >> $GITHUB_STEP_SUMMARY
+echo "1. :key: [Click here to generate a new token](${TOKEN_URL}) called 'Sandpaper Token (${GITHUB_REPOSITORY})' with the "repo" and "workflow" scopes from your GitHub Account" >> $GITHUB_STEP_SUMMARY
 echo "2. :clipboard: Copy your new token to your clipboard" >> $GITHUB_STEP_SUMMARY
 echo "3. Go To https://github.com/${GITHUB_REPOSITORY}/settings/secrets/actions/new" >> $GITHUB_STEP_SUMMARY
 echo "   - enter \`SANDPAPER_WORKFLOW\` for the 'Name'" >> $GITHUB_STEP_SUMMARY

--- a/check-valid-credentials/validate.sh
+++ b/check-valid-credentials/validate.sh
@@ -40,14 +40,16 @@ then
   then
     echo "::set-output name=wf::true"
   else
-    echo "The \`SANDPAPER_WORKFLOW\` secret is missing, invalid," >> $GITHUB_STEP_SUMMARY
-    echo "or does not have the right scope to update the package cache." >> $GITHUB_STEP_SUMMARY
-    echo "If you want to have automated pull request updates to your package cache," >> $GITHUB_STEP_SUMMARY
-    echo "you will need to generate a new token by visiting " >> $GITHUB_STEP_SUMMARY
-    echo "https://github.com/settings/tokens/new?scopes=repo,workflow&description=Sandpaper%20Token%20%28$GH_REPO%29\n" >> $GITHUB_STEP_SUMMARY
-    echo "Once you have created the token, copy it to your clipboard and go to" >> $GITHUB_STEP_SUMMARY
-    echo "https://github.com/$GH_REPO/settings/secrets/actions/new" >> $GITHUB_STEP_SUMMARY
-    echo "and enter SANDPAPER_WORKFLOW for the 'Name' and paste your key for the 'Value'." >> $GITHUB_STEP_SUMMARY
+    echo "The \`SANDPAPER_WORKFLOW\` secret is missing, invalid, or does not" \
+    "have the right scope to update the package cache." >> $GITHUB_STEP_SUMMARY
+    echo "" >> $GITHUB_STEP_SUMMARY
+    echo "If you want to have automated pull request updates to your package cache," \
+    "you will need to generate a new token." >> $GITHUB_STEP_SUMMARY
+    echo "" >> $GITHUB_STEP_SUMMARY
+    echo "1. [Click here to generate a new token from your GitHub Account](https://github.com/settings/tokens/new?scopes=repo,workflow&description=Sandpaper%20Token%20%28$GH_REPO%29)" >> $GITHUB_STEP_SUMMARY
+    echo "2. Copy your new token to your clipboard" >> $GITHUB_STEP_SUMMARY
+    echo "3. Go To https://github.com/$GH_REPO/settings/secrets/actions/new" \
+    "and enter \`SANDPAPER_WORKFLOW\` for the 'Name' and paste your token for the 'Value'." >> $GITHUB_STEP_SUMMARY
   fi
 
   if [[ ${REPO} == 1 ]]

--- a/check-valid-credentials/validate.sh
+++ b/check-valid-credentials/validate.sh
@@ -24,6 +24,9 @@ else
 fi
 mkdir -p ${TMP}
 
+TOKEN_NAME="Sandpaper%20Token%20%28${GITHUB_REPOSITORY}%29"
+TOKEN_URL="https://github.com/settings/tokens/new?scopes=repo,workflow&description=${TOKEN_NAME}"
+
 echo "## :warning: Missing Token" >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
 echo "The \`SANDPAPER_WORKFLOW\` secret is missing, invalid, or does not" \
@@ -34,9 +37,9 @@ echo "If you want to have automated pull request updates to your package cache,"
 echo "" >> $GITHUB_STEP_SUMMARY
 echo "### Steps to Generate a New Token" >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
-echo "1. :key: [Click here to generate a new token from your GitHub Account](https://github.com/settings/tokens/new?scopes=repo,workflow&description=Sandpaper%20Token%20%28$GITHUB_REPOSITORY%29)" >> $GITHUB_STEP_SUMMARY
+echo "1. :key: [Click here to generate a new token called 'Sandpaper Token (${GITHUB_REPOSITORY})' from your GitHub Account](${TOKEN_URL})" >> $GITHUB_STEP_SUMMARY
 echo "2. :clipboard: Copy your new token to your clipboard" >> $GITHUB_STEP_SUMMARY
-echo "3. Go To https://github.com/$GITHUB_REPOSITORY/settings/secrets/actions/new" >> $GITHUB_STEP_SUMMARY
+echo "3. Go To https://github.com/${GITHUB_REPOSITORY}/settings/secrets/actions/new" >> $GITHUB_STEP_SUMMARY
 echo "   - enter \`SANDPAPER_WORKFLOW\` for the 'Name'" >> $GITHUB_STEP_SUMMARY
 echo "   - :inbox_tray: paste your token for the 'Value'" >> $GITHUB_STEP_SUMMARY
 

--- a/check-valid-credentials/validate.sh
+++ b/check-valid-credentials/validate.sh
@@ -36,9 +36,9 @@ echo "### Steps to Generate a New Token" >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
 echo "1. :key: [Click here to generate a new token from your GitHub Account](https://github.com/settings/tokens/new?scopes=repo,workflow&description=Sandpaper%20Token%20%28$GITHUB_REPOSITORY%29)" >> $GITHUB_STEP_SUMMARY
 echo "2. :clipboard: Copy your new token to your clipboard" >> $GITHUB_STEP_SUMMARY
-echo "3. :inbox_tray: Go To https://github.com/$GITHUB_REPOSITORY/settings/secrets/actions/new" >> $GITHUB_STEP_SUMMARY
-echo "  - enter \`SANDPAPER_WORKFLOW\` for the 'Name'" >> $GITHUB_STEP_SUMMARY
-echo "  - paste your token for the 'Value'" >> $GITHUB_STEP_SUMMARY
+echo "3. Go To https://github.com/$GITHUB_REPOSITORY/settings/secrets/actions/new" >> $GITHUB_STEP_SUMMARY
+echo "   - enter \`SANDPAPER_WORKFLOW\` for the 'Name'" >> $GITHUB_STEP_SUMMARY
+echo "   - :inbox_tray: paste your token for the 'Value'" >> $GITHUB_STEP_SUMMARY
 
 if [[ ${PAT} ]]
 then

--- a/check-valid-credentials/validate.sh
+++ b/check-valid-credentials/validate.sh
@@ -24,7 +24,7 @@ else
 fi
 mkdir -p ${TMP}
 
-echo "## Missing Token" >> $GITHUB_STEP_SUMMARY
+echo "## :warning: Missing Token" >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
 echo "The \`SANDPAPER_WORKFLOW\` secret is missing, invalid, or does not" \
 "have the right scope to update the package cache." >> $GITHUB_STEP_SUMMARY
@@ -34,10 +34,11 @@ echo "If you want to have automated pull request updates to your package cache,"
 echo "" >> $GITHUB_STEP_SUMMARY
 echo "### Steps to Generate a New Token" >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
-echo "1. [Click here to generate a new token from your GitHub Account](https://github.com/settings/tokens/new?scopes=repo,workflow&description=Sandpaper%20Token%20%28$GITHUB_REPOSITORY%29)" >> $GITHUB_STEP_SUMMARY
-echo "2. Copy your new token to your clipboard" >> $GITHUB_STEP_SUMMARY
-echo "3. Go To https://github.com/$GITHUB_REPOSITORY/settings/secrets/actions/new" \
-"and enter \`SANDPAPER_WORKFLOW\` for the 'Name' and paste your token for the 'Value'." >> $GITHUB_STEP_SUMMARY
+echo "1. :key: [Click here to generate a new token from your GitHub Account](https://github.com/settings/tokens/new?scopes=repo,workflow&description=Sandpaper%20Token%20%28$GITHUB_REPOSITORY%29)" >> $GITHUB_STEP_SUMMARY
+echo "2. :clipboard: Copy your new token to your clipboard" >> $GITHUB_STEP_SUMMARY
+echo "3. :inbox_tray: Go To https://github.com/$GITHUB_REPOSITORY/settings/secrets/actions/new" >> $GITHUB_STEP_SUMMARY
+echo "  - enter \`SANDPAPER_WORKFLOW\` for the 'Name'" >> $GITHUB_STEP_SUMMARY
+echo "  - paste your token for the 'Value'" >> $GITHUB_STEP_SUMMARY
 
 if [[ ${PAT} ]]
 then
@@ -53,12 +54,13 @@ then
   if [[ ${WORKFLOW} == 1 ]]
   then
     echo "::set-output name=wf::true"
-    rm $GITHUB_STEP_SUMMARY
+    rm -f $GITHUB_STEP_SUMMARY
   fi
 
   if [[ ${REPO} == 1 ]]
   then
     echo "::set-output name=repo::true"
+    rm -f $GITHUB_STEP_SUMMARY
   fi
 
 else

--- a/check-valid-credentials/validate.sh
+++ b/check-valid-credentials/validate.sh
@@ -37,7 +37,7 @@ echo "If you want to have automated pull request updates to your package cache,"
 echo "" >> $GITHUB_STEP_SUMMARY
 echo "### Steps to Generate a New Token" >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
-echo "1. :key: [Click here to generate a new token called 'Sandpaper Token (${GITHUB_REPOSITORY})' from your GitHub Account](${TOKEN_URL})" >> $GITHUB_STEP_SUMMARY
+echo "1. :key: [Click here to generate a new token](${TOKEN_URL}) called 'Sandpaper Token (${GITHUB_REPOSITORY})' from your GitHub Account" >> $GITHUB_STEP_SUMMARY
 echo "2. :clipboard: Copy your new token to your clipboard" >> $GITHUB_STEP_SUMMARY
 echo "3. Go To https://github.com/${GITHUB_REPOSITORY}/settings/secrets/actions/new" >> $GITHUB_STEP_SUMMARY
 echo "   - enter \`SANDPAPER_WORKFLOW\` for the 'Name'" >> $GITHUB_STEP_SUMMARY

--- a/check-valid-credentials/validate.sh
+++ b/check-valid-credentials/validate.sh
@@ -30,14 +30,14 @@ TOKEN_URL="https://github.com/settings/tokens/new?scopes=repo,workflow&descripti
 echo "## :warning: Missing Token" >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
 echo "The \`SANDPAPER_WORKFLOW\` secret is missing, invalid, or does not" \
-"have the right scope to update the package cache." >> $GITHUB_STEP_SUMMARY
+  "have the right scope (repo, workflow) to update the package cache." >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
 echo "If you want to have automated pull request updates to your package cache," \
 "you will need to generate a new token." >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
 echo "### Steps to Generate a New Token" >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
-echo "1. :key: [Click here to generate a new token](${TOKEN_URL}) called 'Sandpaper Token (${GITHUB_REPOSITORY})' with the "repo" and "workflow" scopes from your GitHub Account" >> $GITHUB_STEP_SUMMARY
+echo "1. :key: [Click here to generate a new token](${TOKEN_URL}) called \`Sandpaper Token (${GITHUB_REPOSITORY})\` with the "repo" and "workflow" scopes from your GitHub Account" >> $GITHUB_STEP_SUMMARY
 echo "2. :clipboard: Copy your new token to your clipboard" >> $GITHUB_STEP_SUMMARY
 echo "3. Go To https://github.com/${GITHUB_REPOSITORY}/settings/secrets/actions/new" >> $GITHUB_STEP_SUMMARY
 echo "   - enter \`SANDPAPER_WORKFLOW\` for the 'Name'" >> $GITHUB_STEP_SUMMARY

--- a/check-valid-credentials/validate.sh
+++ b/check-valid-credentials/validate.sh
@@ -38,6 +38,15 @@ then
   if [[ ${WORKFLOW} == 1 ]]
   then
     echo "::set-output name=wf::true"
+  else
+    echo "The \`SANDPAPER_WORKFLOW\` secret is missing, invalid," >> $GITHUB_STEP_SUMMARY
+    echo "or does not have the right scope to update the package cache." >> $GITHUB_STEP_SUMMARY
+    echo "If you want to have automated pull request updates to your package cache," >> $GITHUB_STEP_SUMMARY
+    echo "you will need to generate a new token by visiting " >> $GITHUB_STEP_SUMMARY
+    echo "https://github.com/settings/tokens/new?scopes=repo,workflow&description=Sandpaper%%20Token%%20%%28${{ github.repository }}%%29\n" >> $GITHUB_STEP_SUMMARY
+    echo "Once you have created the token, copy it to your clipboard and go to" >> $GITHUB_STEP_SUMMARY
+    echo "https://github.com/${{ github.repository }}/settings/secrets/actions/new" >> $GITHUB_STEP_SUMMARY
+    echo "and enter SANDPAPER_WORKFLOW for the 'Name' and paste your key for the 'Value'." >> $GITHUB_STEP_SUMMARY
   fi
 
   if [[ ${REPO} == 1 ]]

--- a/check-valid-credentials/validate.sh
+++ b/check-valid-credentials/validate.sh
@@ -39,7 +39,7 @@ then
   then
     echo "::set-output name=wf::true"
   else
-    echo "## Missing Token"
+    echo "## Missing Token" >> $GITHUB_STEP_SUMMARY
     echo "" >> $GITHUB_STEP_SUMMARY
     echo "The \`SANDPAPER_WORKFLOW\` secret is missing, invalid, or does not" \
     "have the right scope to update the package cache." >> $GITHUB_STEP_SUMMARY

--- a/check-valid-credentials/validate.sh
+++ b/check-valid-credentials/validate.sh
@@ -13,6 +13,7 @@ set -eo pipefail
 # Fail if we aren't in a sandpaper repository
 
 PAT=${1:-}
+GH_REPO=${2:-}
 
 # Create a temporary directory for the sandpaper resource files to land in
 if [[ -d ${TMPDIR} ]]; then
@@ -43,9 +44,9 @@ then
     echo "or does not have the right scope to update the package cache." >> $GITHUB_STEP_SUMMARY
     echo "If you want to have automated pull request updates to your package cache," >> $GITHUB_STEP_SUMMARY
     echo "you will need to generate a new token by visiting " >> $GITHUB_STEP_SUMMARY
-    echo "https://github.com/settings/tokens/new?scopes=repo,workflow&description=Sandpaper%%20Token%%20%%28${{ github.repository }}%%29\n" >> $GITHUB_STEP_SUMMARY
+    echo "https://github.com/settings/tokens/new?scopes=repo,workflow&description=Sandpaper%20Token%20%28$GH_REPO%29\n" >> $GITHUB_STEP_SUMMARY
     echo "Once you have created the token, copy it to your clipboard and go to" >> $GITHUB_STEP_SUMMARY
-    echo "https://github.com/${{ github.repository }}/settings/secrets/actions/new" >> $GITHUB_STEP_SUMMARY
+    echo "https://github.com/$GH_REPO/settings/secrets/actions/new" >> $GITHUB_STEP_SUMMARY
     echo "and enter SANDPAPER_WORKFLOW for the 'Name' and paste your key for the 'Value'." >> $GITHUB_STEP_SUMMARY
   fi
 

--- a/check-valid-credentials/validate.sh
+++ b/check-valid-credentials/validate.sh
@@ -13,7 +13,6 @@ set -eo pipefail
 # Fail if we aren't in a sandpaper repository
 
 PAT=${1:-}
-GH_REPO=${2:-}
 
 # Create a temporary directory for the sandpaper resource files to land in
 if [[ -d ${TMPDIR} ]]; then
@@ -40,15 +39,17 @@ then
   then
     echo "::set-output name=wf::true"
   else
+    echo "## Missing Token"
+    echo "" >> $GITHUB_STEP_SUMMARY
     echo "The \`SANDPAPER_WORKFLOW\` secret is missing, invalid, or does not" \
     "have the right scope to update the package cache." >> $GITHUB_STEP_SUMMARY
     echo "" >> $GITHUB_STEP_SUMMARY
     echo "If you want to have automated pull request updates to your package cache," \
     "you will need to generate a new token." >> $GITHUB_STEP_SUMMARY
     echo "" >> $GITHUB_STEP_SUMMARY
-    echo "1. [Click here to generate a new token from your GitHub Account](https://github.com/settings/tokens/new?scopes=repo,workflow&description=Sandpaper%20Token%20%28$GH_REPO%29)" >> $GITHUB_STEP_SUMMARY
+    echo "1. [Click here to generate a new token from your GitHub Account](https://github.com/settings/tokens/new?scopes=repo,workflow&description=Sandpaper%20Token%20%28$GITHUB_REPOSITORY%29)" >> $GITHUB_STEP_SUMMARY
     echo "2. Copy your new token to your clipboard" >> $GITHUB_STEP_SUMMARY
-    echo "3. Go To https://github.com/$GH_REPO/settings/secrets/actions/new" \
+    echo "3. Go To https://github.com/$GITHUB_REPOSITORY/settings/secrets/actions/new" \
     "and enter \`SANDPAPER_WORKFLOW\` for the 'Name' and paste your token for the 'Value'." >> $GITHUB_STEP_SUMMARY
   fi
 

--- a/check-valid-credentials/validate.sh
+++ b/check-valid-credentials/validate.sh
@@ -24,6 +24,21 @@ else
 fi
 mkdir -p ${TMP}
 
+echo "## Missing Token" >> $GITHUB_STEP_SUMMARY
+echo "" >> $GITHUB_STEP_SUMMARY
+echo "The \`SANDPAPER_WORKFLOW\` secret is missing, invalid, or does not" \
+"have the right scope to update the package cache." >> $GITHUB_STEP_SUMMARY
+echo "" >> $GITHUB_STEP_SUMMARY
+echo "If you want to have automated pull request updates to your package cache," \
+"you will need to generate a new token." >> $GITHUB_STEP_SUMMARY
+echo "" >> $GITHUB_STEP_SUMMARY
+echo "### Steps to Generate a New Token" >> $GITHUB_STEP_SUMMARY
+echo "" >> $GITHUB_STEP_SUMMARY
+echo "1. [Click here to generate a new token from your GitHub Account](https://github.com/settings/tokens/new?scopes=repo,workflow&description=Sandpaper%20Token%20%28$GITHUB_REPOSITORY%29)" >> $GITHUB_STEP_SUMMARY
+echo "2. Copy your new token to your clipboard" >> $GITHUB_STEP_SUMMARY
+echo "3. Go To https://github.com/$GITHUB_REPOSITORY/settings/secrets/actions/new" \
+"and enter \`SANDPAPER_WORKFLOW\` for the 'Name' and paste your token for the 'Value'." >> $GITHUB_STEP_SUMMARY
+
 if [[ ${PAT} ]]
 then
 
@@ -38,19 +53,7 @@ then
   if [[ ${WORKFLOW} == 1 ]]
   then
     echo "::set-output name=wf::true"
-  else
-    echo "## Missing Token" >> $GITHUB_STEP_SUMMARY
-    echo "" >> $GITHUB_STEP_SUMMARY
-    echo "The \`SANDPAPER_WORKFLOW\` secret is missing, invalid, or does not" \
-    "have the right scope to update the package cache." >> $GITHUB_STEP_SUMMARY
-    echo "" >> $GITHUB_STEP_SUMMARY
-    echo "If you want to have automated pull request updates to your package cache," \
-    "you will need to generate a new token." >> $GITHUB_STEP_SUMMARY
-    echo "" >> $GITHUB_STEP_SUMMARY
-    echo "1. [Click here to generate a new token from your GitHub Account](https://github.com/settings/tokens/new?scopes=repo,workflow&description=Sandpaper%20Token%20%28$GITHUB_REPOSITORY%29)" >> $GITHUB_STEP_SUMMARY
-    echo "2. Copy your new token to your clipboard" >> $GITHUB_STEP_SUMMARY
-    echo "3. Go To https://github.com/$GITHUB_REPOSITORY/settings/secrets/actions/new" \
-    "and enter \`SANDPAPER_WORKFLOW\` for the 'Name' and paste your token for the 'Value'." >> $GITHUB_STEP_SUMMARY
+    rm $GITHUB_STEP_SUMMARY
   fi
 
   if [[ ${REPO} == 1 ]]


### PR DESCRIPTION
Since GitHub now has Markdown Job Summaries available, I can give a better alert for workflows that don't have valid tokens:

---

## :warning: Missing Token

The `SANDPAPER_WORKFLOW` secret is missing, invalid, or does not have the right scope (repo, workflow) to update the package cache.

If you want to have automated pull request updates to your package cache, you will need to generate a new tokens, it will look something like this:

### Steps to Generate a New Token

1. :key: [Click here to generate a new token](https://github.com/settings/tokens/new?scopes=repo,workflow&description=Sandpaper%20Token%20%28zkamvar/astromantic-atlanticspadefish%29) called `Sandpaper Token (zkamvar/astromantic-atlanticspadefish)` with the repo and workflow scopes from your GitHub Account
2. :clipboard: Copy your new token to your clipboard
3. Go To https://github.com/zkamvar/astromantic-atlanticspadefish/settings/secrets/actions/new
   - enter `SANDPAPER_WORKFLOW` for the 'Name'
   - :inbox_tray: paste your token for the 'Value'

---

This will also allow me to remove a bulky reporting step from the update workflows
