### PR TITLE
check-valid-pr: Include commit invalidation parameter; update messaging

### DIFF
--- a/check-valid-pr/README.md
+++ b/check-valid-pr/README.md
@@ -21,7 +21,7 @@ is very useful in runs that are triggered from pull request workflow runs.
 
 **Required** The default token for authorization. Defaults to `github.token`
 
-### `invalid-hash`
+### `invalid`
 
 A commit that should no longer exist on the production branch in the repository.
 An example is a commit that has been removed by [`git-filter-repo`](https://github.com/newren/git-filter-repo/).
@@ -75,7 +75,7 @@ jobs:
         uses: carpentries/actions/check-valid-pr@add-invalid-hash
         with:
           pr: 2
-          invalid-hash: e83e2c9bdeb259fcb7b12ae21da8f6eac8ff34a4
+          invalid: e83e2c9bdeb259fcb7b12ae21da8f6eac8ff34a4
       - name: "Comment on PR"
         id: comment-diff
         if: ${{ always() }}

--- a/check-valid-pr/action.yaml
+++ b/check-valid-pr/action.yaml
@@ -16,7 +16,7 @@ inputs:
     description: 'github token'
     required: true
     default: ${{ github.token }}
-  invalid-hash:
+  invalid:
     description: 'sha of an invalid commit hash'
     required: false
     default: null

--- a/check-valid-pr/action.yaml
+++ b/check-valid-pr/action.yaml
@@ -26,7 +26,7 @@ outputs:
   payload:
     description: "the JSON from the pull request call"
   MSG:
-    description: "a message that can be sent to the PR in the case of an invalid PR
+    description: "a message that can be sent to the PR in the case of an invalid PR"
 runs:
   using: 'node12'
   main: 'index.js'

--- a/check-valid-pr/action.yaml
+++ b/check-valid-pr/action.yaml
@@ -20,6 +20,10 @@ inputs:
     description: 'sha of an invalid commit hash'
     required: false
     default: null
+  allow-self:
+    description: 'a boolean to allow invalid-hash to be present if the head branch is local to the current repository'
+    required: false
+    default: true
 outputs:
   VALID: 
     description: "flag indicating if the PR is valid. 'true' if valid, 'false' otherwise"

--- a/check-valid-pr/action.yaml
+++ b/check-valid-pr/action.yaml
@@ -16,6 +16,10 @@ inputs:
     description: 'github token'
     required: true
     default: ${{ github.token }}
+  invalid-hash:
+    description: 'sha of an invalid commit hash'
+    required: false
+    default: null
 outputs:
   VALID: 
     description: "flag indicating if the PR is valid. 'true' if valid, 'false' otherwise"

--- a/check-valid-pr/action.yaml
+++ b/check-valid-pr/action.yaml
@@ -25,6 +25,8 @@ outputs:
     description: "flag indicating if the PR is valid. 'true' if valid, 'false' otherwise"
   payload:
     description: "the JSON from the pull request call"
+  MSG:
+    description: "a message that can be sent to the PR in the case of an invalid PR
 runs:
   using: 'node12'
   main: 'index.js'

--- a/check-valid-pr/action.yaml
+++ b/check-valid-pr/action.yaml
@@ -20,10 +20,6 @@ inputs:
     description: 'sha of an invalid commit hash'
     required: false
     default: null
-  allow-self:
-    description: 'a boolean to allow invalid-hash to be present if the head branch is local to the current repository'
-    required: false
-    default: true
 outputs:
   VALID: 
     description: "flag indicating if the PR is valid. 'true' if valid, 'false' otherwise"

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -145,11 +145,14 @@ workflow files:
   if (PR_msg != "") {
     core.setFailed(PR_msg);
   } else {
-    if (pullRequest.data.author_association == "NONE") {
-      // First-time contributors need their PRs approved.
-      PR_msg = `:ok: This pull request has been checked and contains no modified workflow files, spoofing, and invalid commits.
+    // First-time contributors need their PRs approved.
+    PR_msg = `## :ok: Pre-flight checks passed :smiley:
 
-It should be safe to **Approve and Run** the workflows that need maintainer approval.`
+This pull request has been checked and contains no modified workflow files, spoofing, and invalid commits.`;
+    if (pullRequest.data.author_association == "NONE") {
+      PR_msg = `${PR_msg}\n\nIt should be safe to **Approve and Run** the workflows that need maintainer approval.`;
+    } else {
+      PR_msg = `${PR_msg}\n\nResults of any additional workflows will appear here when they are done.`;
     }
   }
   core.setOutput("MSG", PR_msg);

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -56,11 +56,12 @@ async function run() {
       // Use a strategy of checking the comparison between the branch and the
       // bad commit. If the hisotry is divergent, then it is safe to assume that
       // it does not exist on the branch.
-      let bad_origin_request = `GET /repos/{repo}/compare/{branch}...${bad_origin}`
+      let bad_origin_request = `GET /repos/{owner}/{repo}/compare/{branch}...${bad_origin}`
       // This will return a null if there is no comparison and it will reterun
       // "diverged" if the commit is in the history. 
       const { status: comparison } = await octokit.request(bad_origin_request, {
-        repo: that_repo.full_name,
+        owner: that_repo.owner.login,
+        repo: that_repo.name,
         branch: pullRequest.data.head.ref,
       }).catch(err => { 
         if (err.status == '404') {

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -10,7 +10,7 @@ async function run() {
   const PR         = core.getInput('pr');
   const sha        = core.getInput('sha');
   const repository = core.getInput('repo').split('/');
-  const bad_origin = core.getInput('invalid-hash');
+  const bad_origin = core.getInput('invalid');
   const octokit    = github.getOctokit(myToken);
 
   let valid = true; // true if valid and no workflow files are modified

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -61,6 +61,11 @@ async function run() {
       console.log(`SHOULD WE ALLOW THIS? ${bad_origin != '' && is_a_fork}`);
     }
     if (bad_origin != '' && is_a_fork) {
+      // https://stackoverflow.com/a/23970412/2752888
+      //
+      // Use a strategy of checking the comparison between the branch and the
+      // bad commit. If the hisotry is divergent, then it is safe to assume that
+      // it does not exist on the branch.
       let bad_origin_request = `GET /repos/{repo}/compare/{branch}...${bad_origin}`
       const { data: pullRequestCommits } = await octokit.request(bad_origin_request, {
         repo: that_repo.full_name,

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -44,6 +44,7 @@ async function run() {
 
   if (valid) {
     // VALIDITY: bad commit does not exist
+    console.log(`bad_origin: ${bad_origin}`);
     if (bad_origin != null) {
       let bad_origin_request = `GET /repos/{owner}/{repo}/commits?per_page=1?sha=${bad_origin}`
       const { data: pullRequestCommits } = await octokit.request(bad_origin_request, {

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -44,7 +44,7 @@ async function run() {
 
   if (valid) {
     // VALIDITY: bad commit does not exist
-    console.log(`bad_origin: ${bad_origin} is ${typeof(bad_origin)}`);
+    core.setOutput("MSG", PR_msg);
     if (bad_origin != '') {
       let bad_origin_request = `GET /repos/{owner}/{repo}/commits?per_page=1?sha=${bad_origin}`
       const { data: pullRequestCommits } = await octokit.request(bad_origin_request, {
@@ -67,14 +67,14 @@ async function run() {
       if (!valid) {
         PR_msg = `## :danger: DANGER :danger:
 
-        the fork ${pullRequest.data.user.login}/${repository[1]} has divergent
-        history and contains an invalid commit (${bad_origin}) from the former
-        version of this repository before the switch to The Workbench. 
+The fork ${pullRequest.data.user.login}/${repository[1]} has divergent history 
+and contains an invalid commit (${bad_origin}) from the former version of this 
+repository before the switch to The Workbench.
 
-        @${pullRequest.data.user.login}, if you want to contribute your changes,
-        you must [delete your fork](https://docs.github.com/en/repositories/creating-and-managing-repositories/deleting-a-repository) and re-fork this repository.
+@${pullRequest.data.user.login}, if you want to contribute your changes, you 
+must [delete your fork](https://docs.github.com/en/repositories/creating-and-managing-repositories/deleting-a-repository) and re-fork this repository.
         `;
-        console.log(PR_msg);
+        core.setFailed(PR_msg);
         core.setOutput("MSG", PR_msg);
       }
 

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -68,7 +68,7 @@ async function run() {
       valid = pullRequestCommits === null;
       if (!valid) {
         PR_msg = `${PR_msg}
-## :danger: DANGER :danger:
+## :x: DANGER :x:
 
 The fork ${pullRequest.data.user.login}/${repository[1]} has divergent history 
 and contains an invalid commit (${bad_origin}) from the former version of this 

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -82,8 +82,11 @@ The fork ${forkurl} has divergent history and contains an invalid commit (${comm
 
 @${pullRequest.data.user.login}, if you want to contribute your changes, **you must [delete your fork](https://docs.github.com/en/repositories/creating-and-managing-repositories/deleting-a-repository)** and re-fork this repository.
 `;
+        core.setOutput("VALID", valid);
+        core.setOutput("MSG", PR_msg);
+        core.setFailed(PR_msg);
+        process.exit(1);
       }
-
     }
     // create payload output if the PR is not spoofed
     core.setOutput("payload", JSON.stringify(pullRequest));

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -76,7 +76,7 @@ async function run() {
 
 ### DO NOT MERGE THIS PULL REQUEST
 
-The fork ${forkurl} has divergent history and contains an invalid commit (${commiturl}) from the former version of this repository before the switch to The Workbench.
+The fork ${forkurl} has divergent history and contains an invalid commit (${commiturl}).
 
 ### For the Pull Request Author
 
@@ -100,18 +100,24 @@ The fork ${forkurl} has divergent history and contains an invalid commit (${comm
       let valid_files = files.filter(isNotWorkflow);
       // we have a valid PR if the valid file array is unchanged
       valid = valid && valid_files.length == files.length;
-      if (!valid && valid_files.length > 0) {
-        // If we are not valid, we need to check if there is a mix of files
-        let invalid_files = files.filter(e => !isNotWorkflow(e));
-        let vf = valid_files.join(", ");
-        let inv = invalid_files.join(", ");
+      if (!valid) {
         PR_msg = `${PR_msg}
+This pull request contains modified workflow files and no preview will be created.
+
+**Please inspect the changes for any malicious content.**`;
+        if (valid_files.length > 0) {
+          // If we are not valid, we need to check if there is a mix of files
+          let invalid_files = files.filter(e => !isNotWorkflow(e));
+          let vf = valid_files.join(", ");
+          let inv = invalid_files.join(", ");
+          PR_msg = `${PR_msg}
 ## :warning: WARNING :warning:
 
-PR #${PR} contains a mix of workflow files and regular files. **This could be malicious.**
+This pull request contains a mix of workflow files and regular files. **This could be malicious.**
 ->  regular files: ${vf}
 -> workflow files: ${inv}
 `;
+        }
       }
       console.log(`Files in PR: ${files.join(", ")}`);
     } else {

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -145,11 +145,11 @@ workflow files:
   if (PR_msg != "") {
     core.setFailed(PR_msg);
   } else {
-    // First-time contributors need their PRs approved.
     PR_msg = `## :ok: Pre-flight checks passed :smiley:
 
 This pull request has been checked and contains no modified workflow files, spoofing, and invalid commits.`;
     if (pullRequest.data.author_association == "NONE") {
+      // First-time contributors need their PRs approved.
       PR_msg = `${PR_msg}\n\nIt should be safe to **Approve and Run** the workflows that need maintainer approval.`;
     } else {
       PR_msg = `${PR_msg}\n\nResults of any additional workflows will appear here when they are done.`;

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -64,15 +64,15 @@ async function run() {
       // author should be encouraged to remove their repository 
       valid = pullRequestCommits === null;
       if (!valid) {
-        PR_msg = `## :danger: DANGER :danger:
+        PR_msg = "## :danger: DANGER :danger:";
 
-        the fork ${pullRequest.data.user.login}/${repository[1]} has divergent
-        history and contains an invalid commit (${bad_origin}) from the former
-        version of this repository before the switch to The Workbench. 
+//         the fork ${pullRequest.data.user.login}/${repository[1]} has divergent
+//         history and contains an invalid commit (${bad_origin}) from the former
+//         version of this repository before the switch to The Workbench. 
 
-        @${pullRequest.data.user.login}, if you want to contribute your changes,
-        you must [delete your fork](https://docs.github.com/en/repositories/creating-and-managing-repositories/deleting-a-repository) and re-fork this repository.
-        `;
+//         @${pullRequest.data.user.login}, if you want to contribute your changes,
+//         you must [delete your fork](https://docs.github.com/en/repositories/creating-and-managing-repositories/deleting-a-repository) and re-fork this repository.
+//         `;
         core.setOutput("MSG", PR_msg);
       }
 

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -66,13 +66,14 @@ async function run() {
       if (!valid) {
         PR_msg = `## :danger: DANGER :danger:
 
-//         the fork ${pullRequest.data.user.login}/${repository[1]} has divergent
-//         history and contains an invalid commit (${bad_origin}) from the former
-//         version of this repository before the switch to The Workbench. 
+        the fork ${pullRequest.data.user.login}/${repository[1]} has divergent
+        history and contains an invalid commit (${bad_origin}) from the former
+        version of this repository before the switch to The Workbench. 
 
-//         @${pullRequest.data.user.login}, if you want to contribute your changes,
-//         you must [delete your fork](https://docs.github.com/en/repositories/creating-and-managing-repositories/deleting-a-repository) and re-fork this repository.
-//         `;
+        @${pullRequest.data.user.login}, if you want to contribute your changes,
+        you must [delete your fork](https://docs.github.com/en/repositories/creating-and-managing-repositories/deleting-a-repository) and re-fork this repository.
+        `;
+        console.log(PR_msg);
         core.setOutput("MSG", PR_msg);
       }
 

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -67,7 +67,7 @@ async function run() {
       // author should be encouraged to remove their repository 
       valid = pullRequestCommits === null;
       if (!valid) {
-        let PR_msg = `${PR_msg}
+        PR_msg = `${PR_msg}
 ## :danger: DANGER :danger:
 
 The fork ${pullRequest.data.user.login}/${repository[1]} has divergent history 
@@ -100,7 +100,7 @@ must [delete your fork](https://docs.github.com/en/repositories/creating-and-man
         let invalid_files = files.filter(e => !isNotWorkflow(e));
         let vf = valid_files.join(", ");
         let inv = invalid_files.join(", ");
-        let PR_msg = `${PR_msg}
+        PR_msg = `${PR_msg}
 ## :warning: WARNING :warning:
 
 PR #${PR} contains a mix of workflow files and regular files. **This could be malicious.**

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -102,22 +102,26 @@ The fork ${forkurl} has divergent history and contains an invalid commit (${comm
       valid = valid && valid_files.length == files.length;
       if (!valid) {
         let invalid_files = files.filter(e => !isNotWorkflow(e));
-        let inv = invalid_files.join(", ");
+        let inv = invalid_files.join("\n - ");
         PR_msg = `${PR_msg}
 This pull request contains modified workflow files and no preview will be created.
 
-Workflow files modified: ${inv}
+Workflow files modified: 
+
+ - ${inv}
 
 **Please inspect the changes for any malicious content.**`;
         if (valid_files.length > 0) {
           // If we are not valid, we need to check if there is a mix of files
-          let vf = valid_files.join(", ");
+          let vf = valid_files.join("\n - ");
           PR_msg = `${PR_msg}
 ## :warning: WARNING :warning:
 
 This pull request contains a mix of workflow files and regular files. **This could be malicious.**
-->  regular files: ${vf}
--> workflow files: ${inv}
+regular files:    
+ - ${vf}
+-> workflow files:    
+ - ${inv}
 `;
         }
       }

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -68,9 +68,9 @@ async function run() {
       valid = pullRequestCommits === null;
       if (!valid) {
         let ref = pullRequest.data.head.ref
-        let forkurl = `${pullRequest.data.head.repo.html_url}/`
-        let commiturl = `[${pullRequest.data.head.repo.full_name}@${bad_origin}](${forkurl}/tree/${bad_origin})`
-        forkurl = `[${pullRequest.data.head.repo.full_name}@${ref}](${forkurl}/tree/${ref}})`
+        let forkurl = `${pullRequest.data.head.repo.html_url}`
+        let commiturl = `[${bad_origin}](${forkurl}/tree/${bad_origin})`
+        forkurl = `[${pullRequest.data.head.repo.full_name}@${ref}](${forkurl}/tree/${ref})`
         PR_msg = `${PR_msg}
 ## :x: DANGER :x:
 

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -99,7 +99,11 @@ must [delete your fork](https://docs.github.com/en/repositories/creating-and-man
         let invalid_files = files.filter(e => !isNotWorkflow(e));
         let vf = valid_files.join(", ");
         let inv = invalid_files.join(", ");
-        // core.setFailed(`PR #${PR} contains a mix of workflow files and regular files. This could be malicious.\n->  regular files: ${vf}\n-> workflow files: ${inv}`)
+        let PR_msg = `## :warning: WARNING :warning:
+
+PR #${PR} contains a mix of workflow files and regular files. This could be malicious.\n->  regular files: ${vf}\n-> workflow files: ${inv}`;
+        core.setoutput("MSG", PR_msg);
+        core.setFailed(PR_msg);
       }
       console.log(`Files in PR: ${files.join(", ")}`);
     } else {

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -67,7 +67,7 @@ async function run() {
       // bad commit. If the hisotry is divergent, then it is safe to assume that
       // it does not exist on the branch.
       let bad_origin_request = `GET /repos/{repo}/compare/{branch}...${bad_origin}`
-      const comparison = (await octokit.request(bad_origin_request, {
+      const comparison = await octokit.request(bad_origin_request, {
         repo: that_repo.full_name,
         branch: pullRequest.data.head.ref,
       }).catch(err => { 
@@ -79,7 +79,7 @@ async function run() {
           core.setFailed(`There was a problem with the request (Status ${err.status}). See log.`);
           process.exit(1);
         }
-      } ) || {};
+      });
 
       // If we get the bad commit back, then the PR should be closed and the 
       // author should be encouraged to remove their repository 

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -55,7 +55,7 @@ async function run() {
     let is_a_fork = true;
     if (allow_self) {
       console.log("WE ALLOW THE SELF TO PASS THROUGH");
-      let is_a_fork = this_repo.full_name != that_repo.full_name
+      is_a_fork = this_repo.full_name != that_repo.full_name
       console.log(`THIS REPO: ${this_repo.full_name}\nTHAT REPO: ${that_repo.full_name}`);
       console.log(`IS IT A FORK? ${is_a_fork}`);
       console.log(`SHOULD WE ALLOW THIS? ${bad_origin != '' && is_a_fork}`);

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -67,7 +67,7 @@ async function run() {
       // bad commit. If the hisotry is divergent, then it is safe to assume that
       // it does not exist on the branch.
       let bad_origin_request = `GET /repos/{repo}/compare/{branch}...${bad_origin}`
-      const { data: pullRequestCommits } = await octokit.request(bad_origin_request, {
+      const { pullRequestCommits } = await octokit.request(bad_origin_request, {
         repo: that_repo.full_name,
         branch: pullRequest.data.head.ref,
       }).catch(err => { 

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -131,8 +131,12 @@ This pull request contains a mix of workflow files and regular files. **This cou
   core.setOutput("VALID", valid);
   if (PR_msg != "") {
     core.setFailed(PR_msg);
-    core.setOutput("MSG", PR_msg);
+  } else {
+    if (pullRequest.data.author_association == "NONE") {
+      PR_msg = `This pull request has been checked and is safe to test.`
+    }
   }
+  core.setOutput("MSG", PR_msg);
 }
 
 

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -97,7 +97,7 @@ async function run() {
         let invalid_files = files.filter(e => !isNotWorkflow(e));
         let vf = valid_files.join(", ");
         let inv = invalid_files.join(", ");
-        core.setFailed(`PR #${PR} contains a mix of workflow files and regular files. This could be malicious.\n->  regular files: ${vf}\n-> workflow files: ${inv}`)
+        // core.setFailed(`PR #${PR} contains a mix of workflow files and regular files. This could be malicious.\n->  regular files: ${vf}\n-> workflow files: ${inv}`)
       }
       console.log(`Files in PR: ${files.join(", ")}`);
     } else {

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -11,7 +11,6 @@ async function run() {
   const sha        = core.getInput('sha');
   const repository = core.getInput('repo').split('/');
   const bad_origin = core.getInput('invalid-hash');
-  const allow_self = core.getInput('allow-self');
   const octokit    = github.getOctokit(myToken)
 
   function getFilename(f) {

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -67,15 +67,13 @@ async function run() {
       // author should be encouraged to remove their repository 
       valid = pullRequestCommits === null;
       if (!valid) {
+        let forkurl = `${pullRequest.data.head.repo.html_url}/tree/${pullRequest.data.head.ref}`
         PR_msg = `${PR_msg}
 ## :x: DANGER :x:
 
-The fork ${pullRequest.data.user.login}/${repository[1]} has divergent history 
-and contains an invalid commit (${bad_origin}) from the former version of this 
-repository before the switch to The Workbench.
+The fork ${forkurl} has divergent history and contains an invalid commit (${bad_origin}) from the former version of this repository before the switch to The Workbench.
 
-@${pullRequest.data.user.login}, if you want to contribute your changes, you 
-must [delete your fork](https://docs.github.com/en/repositories/creating-and-managing-repositories/deleting-a-repository) and re-fork this repository.
+@${pullRequest.data.user.login}, if you want to contribute your changes, **you must [delete your fork](https://docs.github.com/en/repositories/creating-and-managing-repositories/deleting-a-repository)** and re-fork this repository.
 `;
       }
 

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -61,10 +61,10 @@ async function run() {
       console.log(`SHOULD WE ALLOW THIS? ${bad_origin != '' && is_a_fork}`);
     }
     if (bad_origin != '' && is_a_fork) {
-      let bad_origin_request = `GET /repos/{owner}/{repo}/commits?per_page=1?sha=${bad_origin}`
+      let bad_origin_request = `GET /repos/{repo}/compare/{branch}...${bad_origin}`
       const { data: pullRequestCommits } = await octokit.request(bad_origin_request, {
-        owner: pullRequest.data.user.login,
-        repo: repository[1]
+        repo: that_repo.full_name,
+        branch: pullRequest.data.head.ref,
       }).catch(err => { 
         if (err.status == '404') {
           // status 404 means that we did not see a commit so we can move on.
@@ -78,7 +78,7 @@ async function run() {
 
       // If we get the bad commit back, then the PR should be closed and the 
       // author should be encouraged to remove their repository 
-      valid = pullRequestCommits === null;
+      valid = pullRequestCommits.status == "diverged";
       if (!valid) {
         let ref = pullRequest.data.head.ref
         let forkurl = `${pullRequest.data.head.repo.html_url}`

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -74,9 +74,11 @@ async function run() {
         PR_msg = `${PR_msg}
 ## :x: DANGER :x:
 
-**DO NOT MERGE THIS PULL REQUEST**
+### DO NOT MERGE THIS PULL REQUEST
 
 The fork ${forkurl} has divergent history and contains an invalid commit (${commiturl}) from the former version of this repository before the switch to The Workbench.
+
+### For the Pull Request Author
 
 @${pullRequest.data.user.login}, if you want to contribute your changes, **you must [delete your fork](https://docs.github.com/en/repositories/creating-and-managing-repositories/deleting-a-repository)** and re-fork this repository.
 `;

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -59,12 +59,14 @@ async function run() {
       let bad_origin_request = `GET /repos/{repo}/compare/{branch}...${bad_origin}`
       // This will return a null if there is no comparison and it will reterun
       // "diverged" if the commit is in the history. 
-      const comparison = await octokit.request(bad_origin_request, {
+      const { status: comparison } = await octokit.request(bad_origin_request, {
         repo: that_repo.full_name,
         branch: pullRequest.data.head.ref,
       }).catch(err => { 
         if (err.status == '404') {
           // status 404 means that we did not see a commit so we can move on.
+          console.log("404'd");
+          console.log(err);
           return(null);
         } else {
           console.log(err);

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -64,7 +64,7 @@ async function run() {
       // author should be encouraged to remove their repository 
       valid = pullRequestCommits === null;
       if (!valid) {
-        PR_msg = "## :danger: DANGER :danger:";
+        PR_msg = `## :danger: DANGER :danger:
 
 //         the fork ${pullRequest.data.user.login}/${repository[1]} has divergent
 //         history and contains an invalid commit (${bad_origin}) from the former

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -101,15 +101,17 @@ The fork ${forkurl} has divergent history and contains an invalid commit (${comm
       // we have a valid PR if the valid file array is unchanged
       valid = valid && valid_files.length == files.length;
       if (!valid) {
+        let invalid_files = files.filter(e => !isNotWorkflow(e));
+        let inv = invalid_files.join(", ");
         PR_msg = `${PR_msg}
 This pull request contains modified workflow files and no preview will be created.
+
+Workflow files modified: ${inv}
 
 **Please inspect the changes for any malicious content.**`;
         if (valid_files.length > 0) {
           // If we are not valid, we need to check if there is a mix of files
-          let invalid_files = files.filter(e => !isNotWorkflow(e));
           let vf = valid_files.join(", ");
-          let inv = invalid_files.join(", ");
           PR_msg = `${PR_msg}
 ## :warning: WARNING :warning:
 

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -67,11 +67,16 @@ async function run() {
       // author should be encouraged to remove their repository 
       valid = pullRequestCommits === null;
       if (!valid) {
-        let forkurl = `${pullRequest.data.head.repo.html_url}/tree/${pullRequest.data.head.ref}`
+        let ref = pullRequest.data.head.ref
+        let forkurl = `${pullRequest.data.head.repo.html_url}/`
+        let commiturl = `[${pullRequest.data.head.repo.full_name}@${bad_origin}](${forkurl}/tree/${bad_origin})`
+        let forkurl = `[${pullRequest.data.head.repo.full_name}@${ref}](${forkurl}/tree/${ref}})`
         PR_msg = `${PR_msg}
 ## :x: DANGER :x:
 
-The fork ${forkurl} has divergent history and contains an invalid commit (${bad_origin}) from the former version of this repository before the switch to The Workbench.
+**DO NOT MERGE THIS PULL REQUEST**
+
+The fork ${forkurl} has divergent history and contains an invalid commit (${commiturl}) from the former version of this repository before the switch to The Workbench.
 
 @${pullRequest.data.user.login}, if you want to contribute your changes, **you must [delete your fork](https://docs.github.com/en/repositories/creating-and-managing-repositories/deleting-a-repository)** and re-fork this repository.
 `;

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -62,14 +62,18 @@ async function run() {
 
       // If we get the bad commit back, then the PR should be closed and the 
       // author should be encouraged to remove their repository 
-      if (pullRequestCommits != null) {
-        await octokit.request('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
-          owner: repository[0],
-          repo: repository[1],
-          pull_number: Number(PR),
-          state: 'closed',
-        })
-        core.setFailed(`This PR contains an invalid commit (${bad_origin}).`);
+      valid = pullRequestCommits === null;
+      if (!valid) {
+        PR_msg = `## :danger: DANGER :danger:
+
+        the fork ${pullRequest.data.user.login}/${repository[1]} has divergent
+        history and contains an invalid commit (${bad_origin}) from the former
+        version of this repository before the switch to The Workbench. 
+
+        @${pullRequest.data.user.login}, if you want to contribute your changes,
+        you must [delete your fork](https://docs.github.com/en/repositories/creating-and-managing-repositories/deleting-a-repository) and re-fork this repository.
+        `;
+        core.setOutput("MSG", PR_msg);
       }
 
     }

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -46,7 +46,7 @@ async function run() {
     // VALIDITY: bad commit does not exist
     if (bad_origin != null) {
       let bad_origin_request = `GET /repos/{owner}/{repo}/commits?per_page=1?sha=${bad_origin}`
-      const { data: pullRequestCommits } await octokit.request(bad_origin_request, {
+      const { data: pullRequestCommits } = await octokit.request(bad_origin_request, {
         owner: pullRequest.data.user.login,
         repo: repository[1]
       }).catch(err = { 

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -70,7 +70,7 @@ async function run() {
         let ref = pullRequest.data.head.ref
         let forkurl = `${pullRequest.data.head.repo.html_url}/`
         let commiturl = `[${pullRequest.data.head.repo.full_name}@${bad_origin}](${forkurl}/tree/${bad_origin})`
-        let forkurl = `[${pullRequest.data.head.repo.full_name}@${ref}](${forkurl}/tree/${ref}})`
+        forkurl = `[${pullRequest.data.head.repo.full_name}@${ref}](${forkurl}/tree/${ref}})`
         PR_msg = `${PR_msg}
 ## :x: DANGER :x:
 

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -76,6 +76,7 @@ async function run() {
       // If we get the bad commit back, then the PR should be closed and the 
       // author should be encouraged to remove their repository 
       valid = !comparison || !comparison.status || comparison.status == "diverged";
+      console.log(comparison);
       if (!valid) {
         let ref = pullRequest.data.head.ref
         let forkurl = `${that_repo.html_url}`

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -45,7 +45,7 @@ async function run() {
   if (valid) {
     // VALIDITY: bad commit does not exist
     console.log(`bad_origin: ${bad_origin} is ${typeof(bad_origin)}`);
-    if (bad_origin != null) {
+    if (bad_origin != '') {
       let bad_origin_request = `GET /repos/{owner}/{repo}/commits?per_page=1?sha=${bad_origin}`
       const { data: pullRequestCommits } = await octokit.request(bad_origin_request, {
         owner: pullRequest.data.user.login,

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -81,7 +81,7 @@ async function run() {
           // status 404 means that we did not see a commit so we can move on.
           console.log("404'd");
           console.log(err);
-          return(null);
+          return({data: null});
         } else {
           console.log(err);
           core.setFailed(`Failed to request commit comparison (Status ${err.status}). See log.`);

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -105,12 +105,14 @@ The fork ${forkurl} has divergent history and contains an invalid commit (${comm
         let inv = invalid_files.join("\n - ");
         PR_msg = `${PR_msg}
 
-:information_source: This pull request contains modified workflow files and no preview will be created.
+## :information_source: Modified Workflows
+
+This pull request contains modified workflow files and no preview will be created.
 
 Workflow files modified: 
  - ${inv}
 
-**Please inspect the changes for any malicious content.**`;
+**If this is not from a trusted source, please inspect the changes for any malicious content.**`;
         if (valid_files.length > 0) {
           // If we are not valid, we need to check if there is a mix of files
           let vf = valid_files.join("\n - ");

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -83,9 +83,7 @@ async function run() {
 
       // If we get the bad commit back, then the PR should be closed and the 
       // author should be encouraged to remove their repository 
-      nothing_compares = typeof comparison === "undefined";
-      to_u             = typeof comparison.status === "undefined";
-      valid = nothing_compares || to_u || comparison.status == "diverged";
+      valid = !comparison || !comparison.status || comparison.status == "diverged";
       if (!valid) {
         let ref = pullRequest.data.head.ref
         let forkurl = `${pullRequest.data.head.repo.html_url}`

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -79,7 +79,6 @@ async function run() {
       // If we get the bad commit back, then the PR should be closed and the 
       // author should be encouraged to remove their repository 
       valid = !comparison || !comparison.status || comparison.status == "diverged";
-      console.log(comparison);
       if (!valid) {
         let ref = pullRequest.data.head.ref
         let forkurl = `${that_repo.html_url}`

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -134,7 +134,9 @@ This pull request contains a mix of workflow files and regular files. **This cou
   } else {
     if (pullRequest.data.author_association == "NONE") {
       // First-time contributors need their PRs approved.
-      PR_msg = `This pull request has been checked and should be safe to **Approve and Run** the workflows that need maintainer approval.`
+      PR_msg = `This pull request has been checked and contains no modified workflow files, spoofing, and invalid commits.
+
+It should be safe to **Approve and Run** the workflows that need maintainer approval.`
     }
   }
   core.setOutput("MSG", PR_msg);

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -49,7 +49,7 @@ async function run() {
       const { data: pullRequestCommits } = await octokit.request(bad_origin_request, {
         owner: pullRequest.data.user.login,
         repo: repository[1]
-      }).catch(err = { 
+      }).catch(err => { 
         if (err.status == '404') {
           // status 404 means that we did not see a commit so we can move on.
           return(null);

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -79,8 +79,6 @@ async function run() {
       }).catch(err => { 
         if (err.status == '404') {
           // status 404 means that we did not see a commit so we can move on.
-          console.log("404'd");
-          console.log(err);
           return({data: null});
         } else {
           console.log(err);

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -58,6 +58,7 @@ async function run() {
       let is_a_fork = this_repo.full_name != that_repo.full_name
       console.log(`THIS REPO: ${this_repo.full_name}\nTHAT REPO: ${that_repo.full_name}`);
       console.log(`IS IT A FORK? ${is_a_fork}`);
+      console.log(`SHOULD WE ALLOW THIS? ${bad_origin != '' && is_a_fork}`);
     }
     if (bad_origin != '' && is_a_fork) {
       let bad_origin_request = `GET /repos/{owner}/{repo}/commits?per_page=1?sha=${bad_origin}`

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -54,7 +54,10 @@ async function run() {
     // GitHub keeps track of old refs, even if they have been deleted. 
     let is_a_fork = true;
     if (allow_self) {
-      let is_a_fork = !this_repo.full_name === that_repo.full_name
+      console.log("WE ALLOW THE SELF TO PASS THROUGH");
+      let is_a_fork = this_repo.full_name != that_repo.full_name
+      console.log(`THIS REPO: ${this_repo.full_name}\nTHAT REPO: ${that_repo.full_name}`);
+      console.log(`IS IT A FORK? ${is_a_fork}`);
     }
     if (bad_origin != '' && is_a_fork) {
       let bad_origin_request = `GET /repos/{owner}/{repo}/commits?per_page=1?sha=${bad_origin}`

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -133,7 +133,8 @@ This pull request contains a mix of workflow files and regular files. **This cou
     core.setFailed(PR_msg);
   } else {
     if (pullRequest.data.author_association == "NONE") {
-      PR_msg = `This pull request has been checked and is safe to test.`
+      // First-time contributors need their PRs approved.
+      PR_msg = `This pull request has been checked and should be safe to **Approve and Run** the workflows that need maintainer approval.`
     }
   }
   core.setOutput("MSG", PR_msg);

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -36,6 +36,8 @@ async function run() {
   // VALIDITY: pull request is still open
   let valid = pullRequest.data.state == 'open';
   let msg = `Pull Request ${PR} was previously merged`;
+  let PR_msg = "";
+
   if (sha) {
     // VALIDITY: pull request is IDENTICAL to the provided sha
     valid = valid && pullRequest.data.head.sha == sha;
@@ -65,7 +67,8 @@ async function run() {
       // author should be encouraged to remove their repository 
       valid = pullRequestCommits === null;
       if (!valid) {
-        let PR_msg = `## :danger: DANGER :danger:
+        let PR_msg = `${PR_msg}
+## :danger: DANGER :danger:
 
 The fork ${pullRequest.data.user.login}/${repository[1]} has divergent history 
 and contains an invalid commit (${bad_origin}) from the former version of this 
@@ -73,9 +76,7 @@ repository before the switch to The Workbench.
 
 @${pullRequest.data.user.login}, if you want to contribute your changes, you 
 must [delete your fork](https://docs.github.com/en/repositories/creating-and-managing-repositories/deleting-a-repository) and re-fork this repository.
-        `;
-        core.setFailed(PR_msg);
-        core.setOutput("MSG", PR_msg);
+`;
       }
 
     }
@@ -99,11 +100,13 @@ must [delete your fork](https://docs.github.com/en/repositories/creating-and-man
         let invalid_files = files.filter(e => !isNotWorkflow(e));
         let vf = valid_files.join(", ");
         let inv = invalid_files.join(", ");
-        let PR_msg = `## :warning: WARNING :warning:
+        let PR_msg = `${PR_msg}
+## :warning: WARNING :warning:
 
-PR #${PR} contains a mix of workflow files and regular files. This could be malicious.\n->  regular files: ${vf}\n-> workflow files: ${inv}`;
-        core.setOutput("MSG", PR_msg);
-        core.setFailed(PR_msg);
+PR #${PR} contains a mix of workflow files and regular files. **This could be malicious.**
+->  regular files: ${vf}
+-> workflow files: ${inv}
+`;
       }
       console.log(`Files in PR: ${files.join(", ")}`);
     } else {
@@ -115,6 +118,10 @@ PR #${PR} contains a mix of workflow files and regular files. This could be mali
   }
   console.log(`Is valid?: ${valid}`);
   core.setOutput("VALID", valid);
+  if (PR_msg != "") {
+    core.setFailed(PR_msg);
+    core.setOutput("MSG", PR_msg);
+  }
 }
 
 

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -104,10 +104,10 @@ The fork ${forkurl} has divergent history and contains an invalid commit (${comm
         let invalid_files = files.filter(e => !isNotWorkflow(e));
         let inv = invalid_files.join("\n - ");
         PR_msg = `${PR_msg}
-This pull request contains modified workflow files and no preview will be created.
+
+:information_source: This pull request contains modified workflow files and no preview will be created.
 
 Workflow files modified: 
-
  - ${inv}
 
 **Please inspect the changes for any malicious content.**`;
@@ -118,9 +118,11 @@ Workflow files modified:
 ## :warning: WARNING :warning:
 
 This pull request contains a mix of workflow files and regular files. **This could be malicious.**
+
 regular files:    
  - ${vf}
--> workflow files:    
+
+workflow files:    
  - ${inv}
 `;
         }
@@ -140,7 +142,7 @@ regular files:
   } else {
     if (pullRequest.data.author_association == "NONE") {
       // First-time contributors need their PRs approved.
-      PR_msg = `This pull request has been checked and contains no modified workflow files, spoofing, and invalid commits.
+      PR_msg = `:ok: This pull request has been checked and contains no modified workflow files, spoofing, and invalid commits.
 
 It should be safe to **Approve and Run** the workflows that need maintainer approval.`
     }

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -67,7 +67,7 @@ async function run() {
       // bad commit. If the hisotry is divergent, then it is safe to assume that
       // it does not exist on the branch.
       let bad_origin_request = `GET /repos/{repo}/compare/{branch}...${bad_origin}`
-      const { pullRequestCommits } = await octokit.request(bad_origin_request, {
+      const comparison = (await octokit.request(bad_origin_request, {
         repo: that_repo.full_name,
         branch: pullRequest.data.head.ref,
       }).catch(err => { 
@@ -79,11 +79,13 @@ async function run() {
           core.setFailed(`There was a problem with the request (Status ${err.status}). See log.`);
           process.exit(1);
         }
-      } );
+      } ) || {};
 
       // If we get the bad commit back, then the PR should be closed and the 
       // author should be encouraged to remove their repository 
-      valid = pullRequestCommits.status == "diverged";
+      nothing_compares = typeof comparison === "undefined";
+      to_u             = typeof comparison.status === "undefined";
+      valid = nothing_compares || to_u || comparison.status == "diverged";
       if (!valid) {
         let ref = pullRequest.data.head.ref
         let forkurl = `${pullRequest.data.head.repo.html_url}`

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -59,7 +59,7 @@ async function run() {
       let bad_origin_request = `GET /repos/{owner}/{repo}/compare/{branch}...${bad_origin}`
       // This will return a null if there is no comparison and it will reterun
       // "diverged" if the commit is in the history. 
-      const { status: comparison } = await octokit.request(bad_origin_request, {
+      const { data: comparison } = await octokit.request(bad_origin_request, {
         owner: that_repo.owner.login,
         repo: that_repo.name,
         branch: pullRequest.data.head.ref,

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -44,7 +44,7 @@ async function run() {
 
   if (valid) {
     // VALIDITY: bad commit does not exist
-    console.log(`bad_origin: ${bad_origin}`);
+    console.log(`bad_origin: ${bad_origin} is ${typeof(bad_origin)}`);
     if (bad_origin != null) {
       let bad_origin_request = `GET /repos/{owner}/{repo}/commits?per_page=1?sha=${bad_origin}`
       const { data: pullRequestCommits } = await octokit.request(bad_origin_request, {

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -102,7 +102,7 @@ must [delete your fork](https://docs.github.com/en/repositories/creating-and-man
         let PR_msg = `## :warning: WARNING :warning:
 
 PR #${PR} contains a mix of workflow files and regular files. This could be malicious.\n->  regular files: ${vf}\n-> workflow files: ${inv}`;
-        core.setoutput("MSG", PR_msg);
+        core.setOutput("MSG", PR_msg);
         core.setFailed(PR_msg);
       }
       console.log(`Files in PR: ${files.join(", ")}`);

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -44,7 +44,7 @@ async function run() {
 
   if (valid) {
     // VALIDITY: bad commit does not exist
-    core.setOutput("MSG", PR_msg);
+    core.setOutput("MSG", '');
     if (bad_origin != '') {
       let bad_origin_request = `GET /repos/{owner}/{repo}/commits?per_page=1?sha=${bad_origin}`
       const { data: pullRequestCommits } = await octokit.request(bad_origin_request, {
@@ -65,7 +65,7 @@ async function run() {
       // author should be encouraged to remove their repository 
       valid = pullRequestCommits === null;
       if (!valid) {
-        PR_msg = `## :danger: DANGER :danger:
+        let PR_msg = `## :danger: DANGER :danger:
 
 The fork ${pullRequest.data.user.login}/${repository[1]} has divergent history 
 and contains an invalid commit (${bad_origin}) from the former version of this 


### PR DESCRIPTION
For the [Beta Phase of The Carpentries Workbench](https://carpentries.org/blog/2022/05/workbench-beta/), we are going to be running repositories through [git-filter-repo](https://github.com/newren/git-filter-repo/#readme).

In short, this means that history will be rewritten and anyone who has previously forked a repo, will need to delete the fork and re-fork if they want to contribute. 

The challenge is when people try to fix their forks, they can end up with a history that is interwoven with commits from styles that we have removed in git-filter-repo and this will appear as a pull request with hundreds of irrelevant commits, even for a small one-line change. 

This PR does a few things:

1. it adds a parameter to the check-valid-pr action called `invalid-hash` which will take in a hash that should not exist in the fork.
2. it adds and output parameter MSG that will contain markdown-formatted information for a comment.
3. It provides clear errors/warnings and notes for different levels of caution in the validation steps.

<details>
<summary>**Examples of pull request comments**</summary>

## :ok: Pre-flight checks passed :smiley:

This pull request has been checked and contains no modified workflow files, spoofing, or invalid commits.

It should be safe to **Approve and Run** the workflows that need maintainer approval.

---

## :information_source: Modified Workflows

This pull request contains modified workflow files and no preview will be created.

Workflow files modified: 
 - .github/workflows/pkgdown.yaml

**If this is not from a trusted source, please inspect the changes for any malicious content.**

---

## :warning: WARNING :warning:

This pull request contains a mix of workflow files and regular files. **This could be malicious.**

regular files:    
 - tools/convertversion.sh

workflow files:    
 - .github/workflows/pkgdown.yaml

---

## :x: DANGER :x:

### DO NOT MERGE THIS PULL REQUEST

The fork [zkamvar/laughing-winner@zkamvar-patch-4](https://github.com/zkamvar/laughing-winner/tree/zkamvar-patch-4) has divergent history and contains an invalid commit ([6d0c122455837d4339e486140377d71701344e51](https://github.com/zkamvar/laughing-winner/tree/6d0c122455837d4339e486140377d71701344e51)).

### For the Pull Request Author

@zkamvar, if you want to contribute your changes, **you must [delete your fork](https://docs.github.com/en/repositories/creating-and-managing-repositories/deleting-a-repository)** and re-fork this repository.

---

</details>

I've also tested this using a workflow that runs on `pull_request_target`, which cannot be modified by pull request, so there is no danger of spoofing. 

In a perfect world, I would be able to use `e83e2c9bdeb259fcb7b12ae21da8f6eac8ff34a4` as the expected hash, but we don't live in a perfect world and there are lessons that were generated using the remote themes template and there were lessons like the R-ecology-lesson which did have that hash once upon a time (which github gladly returns), but moved to an independent sort of build. 

I have begun including these in https://files.carpentries.org/invalid-hashes.json so they can be queried with the repository name. NOTE: this may not be the most reliable setup due to CDN propagation 😬 