### PR TITLE
use mktemp instead of rolling my own

### DIFF
--- a/update-workflows/update-workflows.sh
+++ b/update-workflows/update-workflows.sh
@@ -42,14 +42,7 @@ elif [[ ${SOURCE} == 'https://carpentries.r-universe.dev' ]]; then
 fi
 
 # Create a temporary directory for the sandpaper resource files to land in
-if [[ -d ${TMPDIR} ]]; then
-  TMP="${TMPDIR}/sandpaper-${RANDOM}"
-elif [[ -d /tmp/ ]]; then
-  TMP="/tmp/sandpaper-${RANDOM}"
-else
-  TMP="../sandpaper-${RANDOM}"
-fi
-mkdir -p ${TMP}
+TMP=$(mktemp -d)
 
 # Show the version inforamtion
 echo "::group::Version Information"


### PR DESCRIPTION
For some reason, I had thought that temporary directories in BASH were set up through the TEMPDIR variable or something similar and you just could play around in there.

It turns out that `mktemp -d` is the right answer to creating temporary
directories: https://twitter.com/henrikbengtsson/status/1577368529132695553
