### PR TITLE
update check-valid-pr to include headroom

### DIFF
--- a/check-valid-pr/action.yaml
+++ b/check-valid-pr/action.yaml
@@ -8,6 +8,10 @@ inputs:
     description: 'sha of the latest head'
     required: false
     default: null
+  headroom:
+    description: 'number of commits for sha to be found'
+    required: false
+    default: 1
   repo:
     description: 'github repository (default: current repository)'
     required: true

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -65,7 +65,7 @@ async function run() {
     console.log(headroom > 1);
     console.log(headroom);
     if (!sha_valid && headroom > 1) {
-      const commits = await octokit.graphql(
+      const { repository.pullRequest.commits: commits } = await octokit.graphql(
         `
         query lastCommits($owner: String!, $repo: String!, $pull_number: Int = 1, $n: Int = 1) {
           repository(owner: $owner, name: $repo) {
@@ -96,9 +96,9 @@ async function run() {
         process.exit(1);
       });
       console.log(commits);
-      console.log(commits.repository.pullRequest.commits.edges.map(getSHA));
-      console.log(commits.repository.pullRequest.commits.edges.map(getSHA).includes(sha));
-      sha_valid = commits.repository.pullRequest.commits.edges.map(getSHA).includes(sha);
+      console.log(commits.edges.map(getSHA));
+      console.log(commits.edges.map(getSHA).includes(sha));
+      sha_valid = commits.edges.map(getSHA).includes(sha);
       console.log(sha_valid);
     }
     valid = valid && sha_valid

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -96,9 +96,9 @@ async function run() {
         process.exit(1);
       });
       console.log(commits);
-      console.log(commits.data.repository.pullRequest.commits.edges.map(getSHA));
-      console.log(commits.data.repository.pullRequest.commits.edges.map(getSHA).includes(sha));
-      sha_valid = commits.data.repository.pullRequest.commits.edges.map(getSHA).includes(sha);
+      console.log(commits.repository.pullRequest.commits.edges.map(getSHA));
+      console.log(commits.repository.pullRequest.commits.edges.map(getSHA).includes(sha));
+      sha_valid = commits.repository.pullRequest.commits.edges.map(getSHA).includes(sha);
       console.log(sha_valid);
     }
     valid = valid && sha_valid

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -57,9 +57,16 @@ async function run() {
   // --- CHECK: pull request is IDENTICAL to the provided sha
   if (sha) {
     let sha_valid = pullRequest.data.head.sha == sha;
+    // Here, we want to check if the commits that we are testing is in the last
+    // number of commits as indicated by 'headroom'. 
+    //
+    // Right now, my strategy is not working. because the request I am using
+    // returns the number of commits starting with the oldest commit. 
     console.log(headroom > 1);
     console.log(headroom);
     if (!sha_valid && headroom > 1) {
+      let fork_name = pullRequest.data.repo.full_name;
+      let ref = pullRequest.data.ref
       let crqs = 'GET /repos/{owner}/{repo}/pulls/{pull_number}/commits{?per_page,page}';
       const { data: commits } = await octokit.request(crqs, {
         owner: repository[0],

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -48,7 +48,7 @@ async function run() {
 
   // STEP 2: Perform Checks ----------------------------------------------------
   // --- CHECK: pull request is still open 
-  console.log(`checking if PR (#${PR}) was previously merged`);
+  console.log(`checking if PR #${PR} was previously merged`);
   valid = pullRequest.data.state == 'open';
   if (!valid) {
     MSG = `${MSG} **NOTE:** This Pull Request (#${PR}) was previously merged`;
@@ -64,8 +64,6 @@ async function run() {
     //
     // Right now, my strategy is not working. because the request I am using
     // returns the number of commits starting with the oldest commit. 
-    console.log(headroom > 1);
-    console.log(headroom);
     if (!sha_valid && headroom > 1) {
       console.log(`checking if ${sha} is within last ${headroom} commits`);
       const commits = await octokit.graphql(
@@ -98,8 +96,8 @@ async function run() {
         core.setFailed(`There was a problem with the request (Status ${err.status}). See log.`);
         process.exit(1);
       });
+      // the commit is valid if sha is included within the last n commits
       sha_valid = commits.repository.pullRequest.commits.edges.map(getSHA).includes(sha);
-      console.log(sha_valid);
     }
     valid = valid && sha_valid
     pass = valid;

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -48,6 +48,7 @@ async function run() {
 
   // STEP 2: Perform Checks ----------------------------------------------------
   // --- CHECK: pull request is still open 
+  console.log(`checking if PR (#${PR}) was previously merged`);
   valid = pullRequest.data.state == 'open';
   if (!valid) {
     MSG = `${MSG} **NOTE:** This Pull Request (#${PR}) was previously merged`;
@@ -56,6 +57,7 @@ async function run() {
 
   // --- CHECK: pull request is IDENTICAL to the provided sha
   if (sha) {
+    console.log(`checking if ${sha} is HEAD commit`);
     let sha_valid = pullRequest.data.head.sha == sha;
     // Here, we want to check if the commits that we are testing is in the last
     // number of commits as indicated by 'headroom'. 
@@ -65,6 +67,7 @@ async function run() {
     console.log(headroom > 1);
     console.log(headroom);
     if (!sha_valid && headroom > 1) {
+      console.log(`checking if ${sha} is within last ${headroom} commits`);
       const commits = await octokit.graphql(
         `
         query lastCommits($owner: String!, $repo: String!, $pull_number: Int = 1, $n: Int = 1) {
@@ -95,9 +98,6 @@ async function run() {
         core.setFailed(`There was a problem with the request (Status ${err.status}). See log.`);
         process.exit(1);
       });
-      console.log(commits);
-      console.log(commits.repository.pullRequest.commits.edges.map(getSHA));
-      console.log(commits.repository.pullRequest.commits.edges.map(getSHA).includes(sha));
       sha_valid = commits.repository.pullRequest.commits.edges.map(getSHA).includes(sha);
       console.log(sha_valid);
     }
@@ -127,6 +127,7 @@ async function run() {
     //     because GitHub keeps track of old refs, even if they have been
     //     deleted. 
     if (bad_origin != '') {
+      console.log(`checking for the invalid commit ${bad_origin}`);
       // https://stackoverflow.com/a/23970412/2752888
       //
       // Use a strategy of checking the comparison between the branch and the
@@ -181,6 +182,7 @@ The fork ${forkurl} has divergent history and contains an invalid commit (${comm
         }
       }
     }
+    console.log(`checking files in the pull request`);
     // What files are associated? ----------------------------------------------
     const { data: pullRequestFiles } = await octokit.pulls.listFiles({
       owner: repository[0],

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -67,7 +67,7 @@ async function run() {
     if (!sha_valid && headroom > 1) {
       const { commits } = await octokit.graphql(
         `
-        query lastCommits($owner: String!, $repo: String!, $pull_number: Int!, $n: Int = 1){
+        query lastCommits($owner: String!, $repo: String!, $pull_number: Int = 1, $n: Int = 1) {
           repository(owner: $owner, name: $repo) {
             pullRequest(number: $pull_number) {
               commits(last: $n) {

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -65,7 +65,7 @@ async function run() {
     console.log(headroom > 1);
     console.log(headroom);
     if (!sha_valid && headroom > 1) {
-      const { commits } = await octokit.graphql(
+      const { data: commits } = await octokit.graphql(
         `
         query lastCommits($owner: String!, $repo: String!, $pull_number: Int!, $n: Int = 1){
           repository(owner: $owner, name: $repo) {

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -73,6 +73,8 @@ async function run() {
         process.exit(1);
       });
       console.log(commits.map(getSHA));
+      console.log(sha);
+      console.log(commits.map(getSHA).includes(sha));
       sha_valid = commits.map(getSHA).includes(sha);
       console.log(sha_valid);
     }

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -70,7 +70,9 @@ async function run() {
         core.setFailed(`There was a problem with the request (Status ${err.status}). See log.`);
         process.exit(1);
       });
+      console.log(commits.map(getSHA));
       sha_valid = commits.map(getSHA).includes(sha);
+      console.log(sha_valid);
     }
     valid = valid && sha_valid
     pass = valid;

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -65,7 +65,7 @@ async function run() {
     console.log(headroom > 1);
     console.log(headroom);
     if (!sha_valid && headroom > 1) {
-      const { repository { pullRequest { commits: commits } } } = await octokit.graphql(
+      const commits = await octokit.graphql(
         `
         query lastCommits($owner: String!, $repo: String!, $pull_number: Int = 1, $n: Int = 1) {
           repository(owner: $owner, name: $repo) {
@@ -96,9 +96,9 @@ async function run() {
         process.exit(1);
       });
       console.log(commits);
-      console.log(commits.edges.map(getSHA));
-      console.log(commits.edges.map(getSHA).includes(sha));
-      sha_valid = commits.edges.map(getSHA).includes(sha);
+      console.log(commits.repository.pullRequest.commits.edges.map(getSHA));
+      console.log(commits.repository.pullRequest.commits.edges.map(getSHA).includes(sha));
+      sha_valid = commits.repository.pullRequest.commits.edges.map(getSHA).includes(sha);
       console.log(sha_valid);
     }
     valid = valid && sha_valid

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -65,7 +65,7 @@ async function run() {
     console.log(headroom > 1);
     console.log(headroom);
     if (!sha_valid && headroom > 1) {
-      const { repository.pullRequest.commits: commits } = await octokit.graphql(
+      const { repository { pullRequest { commits: commits } } } = await octokit.graphql(
         `
         query lastCommits($owner: String!, $repo: String!, $pull_number: Int = 1, $n: Int = 1) {
           repository(owner: $owner, name: $repo) {

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -57,6 +57,8 @@ async function run() {
   // --- CHECK: pull request is IDENTICAL to the provided sha
   if (sha) {
     let sha_valid = pullRequest.data.head.sha == sha;
+    console.log(headroom > 1);
+    console.log(headroom);
     if (!sha_valid && headroom > 1) {
       let crqs = 'GET /repos/{owner}/{repo}/pulls/{pull_number}/commits{?per_page,page}';
       const { data: commits } = await octokit.request(crqs, {

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -65,7 +65,7 @@ async function run() {
     console.log(headroom > 1);
     console.log(headroom);
     if (!sha_valid && headroom > 1) {
-      const { data: commits } = await octokit.graphql(
+      const { commits } = await octokit.graphql(
         `
         query lastCommits($owner: String!, $repo: String!, $pull_number: Int!, $n: Int = 1){
           repository(owner: $owner, name: $repo) {
@@ -95,6 +95,7 @@ async function run() {
         core.setFailed(`There was a problem with the request (Status ${err.status}). See log.`);
         process.exit(1);
       });
+      console.log(commits);
       console.log(commits.data.repository.pullRequest.commits.edges.map(getSHA));
       console.log(commits.data.repository.pullRequest.commits.edges.map(getSHA).includes(sha));
       sha_valid = commits.data.repository.pullRequest.commits.edges.map(getSHA).includes(sha);

--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -65,7 +65,7 @@ async function run() {
     console.log(headroom > 1);
     console.log(headroom);
     if (!sha_valid && headroom > 1) {
-      const { commits } = await octokit.graphql(
+      const commits = await octokit.graphql(
         `
         query lastCommits($owner: String!, $repo: String!, $pull_number: Int = 1, $n: Int = 1) {
           repository(owner: $owner, name: $repo) {


### PR DESCRIPTION
This adds the `headroom` argument to the check-valid-pr action. This argument
specifies a range of commits that we can expect `sha` to be in. The default is
1, which is the same as the current behaviour. This is a fallback in the race
condition where a new commit is added to the PR after the workflow containing
this action is started.


