### PR TITLE
allow current renv

### DIFF
--- a/setup-lesson-deps/action.yaml
+++ b/setup-lesson-deps/action.yaml
@@ -124,8 +124,7 @@ runs:
             } else {
               try(file.remove("DESCRIPTION"), silent = TRUE)
             }
-            # install renv 0.16.0 to avoid https://github.com/carpentries/lesson-transition/issues/18
-            install.packages("https://cran.r-project.org/src/contrib/Archive/renv/renv_0.16.0.tar.gz")
+            req("renv")
             Sys.setenv("RENV_PROFILE" = "lesson-requirements")
             sandpaper::manage_deps(path = wd, quiet = FALSE)
             cat("::endgroup::\n")


### PR DESCRIPTION
This reverts https://github.com/carpentries/actions/commit/62b18a9eed6e3ba2d2204213b8fb989236cb0849, which temporarily restricted {renv} to version 0.16.0 because we could not provision new packages with renv 0.17.2. https://github.com/carpentries/sandpaper/pull/423 has hopefully fixed this issue