### PR TITLE
fix incorrect posit.co URL

### DIFF
--- a/setup-lesson-deps/action.yaml
+++ b/setup-lesson-deps/action.yaml
@@ -39,7 +39,7 @@ runs:
             RSPM        = Sys.getenv("RSPM"),
             carpentries = "https://carpentries.r-universe.dev/",
             archive     = "https://carpentries.github.io/drat/",
-            CRAN        = "https://cran.posit.co"
+            CRAN        = "https://cran.rstudio.com"
           )
           options(pak.no_extra_messages = TRUE, repos = repos)
           cat("Repositories Used")
@@ -98,7 +98,7 @@ runs:
             RSPM        = Sys.getenv("RSPM"),
             carpentries = "https://carpentries.r-universe.dev/",
             archive     = "https://carpentries.github.io/drat/",
-            CRAN        = "https://cran.posit.co"
+            CRAN        = "https://cran.rstudio.com"
           )
           Sys.unsetenv("RENV_CONFIG_REPOS_OVERRIDE")
           options(pak.no_extra_messages = TRUE, repos = repos)

--- a/setup-sandpaper/action.yaml
+++ b/setup-sandpaper/action.yaml
@@ -23,7 +23,7 @@ runs:
             if (Sys.getenv("RSPM") == "") {
               release <- system("lsb_release -c | awk '{print $2}'", intern = TRUE)
               Sys.setenv("RSPM" = 
-                paste0("https://packagemanager.rstudio.com/all/__linux__/", release, "/latest"))
+                paste0("https://packagemanager.posit.co/all/__linux__/", release, "/latest"))
             }
           }
           repos <- list(
@@ -93,7 +93,7 @@ runs:
             if (Sys.getenv("RSPM") == "") {
               release <- system("lsb_release -c | awk '{print $2}'", intern = TRUE)
               Sys.setenv("RSPM" = 
-                paste0("https://packagemanager.rstudio.com/all/__linux__/", release, "/latest"))
+                paste0("https://packagemanager.posit.co/all/__linux__/", release, "/latest"))
             }
           }
           repos <- list(


### PR DESCRIPTION
This paritally reverts 5d032830da32be0627c84439fe25ba9ecc5b4aae,
addressing changes proposed in #75 and #76

It turns out that posit only changed the URL to their packagemanager, and this
CRAN URL will cause problems in the future.
