### PR TITLE
[setup-sandpaper] do not check the drat archive for versions

### DIFF
--- a/setup-sandpaper/action.yaml
+++ b/setup-sandpaper/action.yaml
@@ -32,7 +32,6 @@ runs:
           repos <- list(
             RSPM        = Sys.getenv("RSPM"),
             carpentries = "https://carpentries.r-universe.dev/",
-            archive     = "https://carpentries.github.io/drat/",
             CRAN        = "https://cran.rstudio.com"
           )
           options(pak.no_extra_messages = TRUE, repos = repos)
@@ -102,7 +101,6 @@ runs:
           repos <- list(
             RSPM        = Sys.getenv("RSPM"),
             carpentries = "https://carpentries.r-universe.dev/",
-            archive     = "https://carpentries.github.io/drat/",
             CRAN        = "https://cran.rstudio.com"
           )
           options(pak.no_extra_messages = TRUE, repos = repos)


### PR DESCRIPTION
This is the cause of https://github.com/carpentries/varnish/pull/91#issuecomment-1698269890

It appears that I am accidentally releasing unreleased versions of the workbench packages whenever I push to main! This is _not_ what I need right now. 

This is going to complement #83 and should be merged _before_ it. 