### PR TITLE
[update-lockfile] create artifact of renv folder

### DIFF
--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -77,7 +77,7 @@ runs:
               rmts$supported_os_versions <- sov
             }
             req("desc")
-            remotes::install_github("zkamvar/vise")
+            remotes::install_github("carpentries/vise@fix-hydrate-actions-88")
             Sys.setenv("RENV_PROFILE" = "lesson-requirements")
             Sys.setenv("RSPM_ROOT" = "https://packagemanager.posit.co")
             vise::ci_sysreqs(renv::paths$lockfile(), execute = TRUE)

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -122,7 +122,7 @@ runs:
       - name: "Upload renv folder as artifact (extract as renv/)"
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.repository}}/renv
+          name: renv
           path: |
             ${{ github.workspace }}/renv/
             !${{ github.workspace }}/renv/profiles/${{ inputs.profile }}/renv/library

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -77,7 +77,7 @@ runs:
               rmts$supported_os_versions <- sov
             }
             req("desc")
-            remotes::install_github("carpentries/vise@fix-hydrate-actions-88")
+            remotes::install_github("carpentries/vise")
             Sys.setenv("RENV_PROFILE" = "lesson-requirements")
             Sys.setenv("RSPM_ROOT" = "https://packagemanager.posit.co")
             vise::ci_sysreqs(renv::paths$lockfile(), execute = TRUE)

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -119,11 +119,16 @@ runs:
             repos = "${{ inputs.repos }}")
           cat("::endgroup::\n")
 
-      - name: "Upload Lockfile"
+      - name: "Upload renv folder"
         uses: actions/upload-artifact@v3
         with:
-          name: lockfile 
-          path: "${{ github.workspace }}/renv/profiles/${{ inputs.profile }}/renv.lock"
+          name: renv-lock
+          path: 
+            ${{ github.workspace }}/renv/
+            !${{ github.workspace }}/renv/profiles/${{ inputs.profile }}/renv/library
+            !${{ github.workspace }}/renv/profiles/${{ inputs.profile }}/renv/staging
+
+
           retention-days: 30
 
       - name: Don't use tar 1.30 from Rtools35 to store the cache

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -119,10 +119,10 @@ runs:
             repos = "${{ inputs.repos }}")
           cat("::endgroup::\n")
 
-      - name: "Upload renv folder"
+      - name: "Upload renv folder as artifact (extract as renv/)"
         uses: actions/upload-artifact@v3
         with:
-          name: renv-lock
+          name: ${{ github.repository}}/renv
           path: |
             ${{ github.workspace }}/renv/
             !${{ github.workspace }}/renv/profiles/${{ inputs.profile }}/renv/library

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -123,7 +123,7 @@ runs:
         uses: actions/upload-artifact@v3
         with:
           name: renv-lock
-          path: 
+          path: |
             ${{ github.workspace }}/renv/
             !${{ github.workspace }}/renv/profiles/${{ inputs.profile }}/renv/library
             !${{ github.workspace }}/renv/profiles/${{ inputs.profile }}/renv/staging

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -119,6 +119,13 @@ runs:
             repos = "${{ inputs.repos }}")
           cat("::endgroup::\n")
 
+      - name: "Upload Lockfile"
+        uses: actions/upload-artifact@v3
+        with:
+          name: lockfile 
+          path: "${{ github.workspace }}/renv/profiles/${{ inputs.profile }}/renv.lock"
+          retention-days: 30
+
       - name: Don't use tar 1.30 from Rtools35 to store the cache
         shell: bash
         run: |


### PR DESCRIPTION
This will create an archive of the renv/ folder that will be available for 30 days. 

It will allow people to apply the changes even if they do not have bot token access (though this needs to be changed inside the workflow)


