### PR TITLE
use node20

### DIFF
--- a/check-valid-pr/action.yaml
+++ b/check-valid-pr/action.yaml
@@ -36,5 +36,5 @@ outputs:
   MSG:
     description: "a message that can be sent to the PR in the case of an invalid PR"
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/comment-diff/action.yaml
+++ b/comment-diff/action.yaml
@@ -19,5 +19,5 @@ inputs:
     required: true
     default: ${{ github.token }}
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/download-workflow-artifact/action.yaml
+++ b/download-workflow-artifact/action.yaml
@@ -23,5 +23,5 @@ outputs:
   success:
     description: "a boolean variable if the download was successful (true) or not (false)"
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/remove-branch/action.yaml
+++ b/remove-branch/action.yaml
@@ -17,5 +17,5 @@ inputs:
     required: true
     default: ${{ github.token }}
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'


### PR DESCRIPTION
Updates the actions to use Node version 20 instead of 16. We have been getting deprecation warnings on several Workbench workflows for the last few months. See [_GitHub Actions: Transitioning from Node 16 to Node 20_](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/). 

I _think_ this is as much as needs to be changed to address the issue but I would strongly recommend testing it out before merging, because:

![I have no idea what I am doing.](https://github.com/carpentries/actions/assets/9694524/9b8cecda-3f91-4662-aac6-7a3afc4bab68)

