### PR TITLE
ENH: Fix `Node.js` warnings linked to GitHub actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: "Checkout Pull Request"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: "Create PR Number"
         id: get-number
@@ -19,7 +19,7 @@ jobs:
 
       - name: "Upload Artifact"
         id: upload-number
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pr
           path: NUM

--- a/.github/workflows/test-check-credentials.yaml
+++ b/.github/workflows/test-check-credentials.yaml
@@ -13,7 +13,7 @@ jobs:
       srepo:  ${{ steps.sandpaper.outputs.repo }}
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: "Validate Token"
         id: check

--- a/.github/workflows/test-check-valid-pr.yaml
+++ b/.github/workflows/test-check-valid-pr.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: Testing PR states
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - id: valid-pr
         name: "Valid PR"
         uses: carpentries/actions/check-valid-pr@main

--- a/.github/workflows/test-comment-pr.yaml
+++ b/.github/workflows/test-comment-pr.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: Testing Comment on PR
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: |
           printf "### Test Comment\n" > ${{ github.workspace }}/body.txt
           printf ":heavy_check_mark: The ID for this run is ${{ github.run_id }}" >> ${{ github.workspace }}/body.txt

--- a/setup-lesson-deps/action.yaml
+++ b/setup-lesson-deps/action.yaml
@@ -17,7 +17,7 @@ runs:
         shell: Rscript {0}
 
       - name: "Restore {renv} Cache"
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: ${{ env.RENV_PATHS_ROOT }}
           key: renv-${{ steps.get-version.outputs.os-version }}-${{ steps.get-version.outputs.r-version }}-${{inputs.cache-version }}-${{ hashFiles('**/renv.lock') }}

--- a/setup-sandpaper/action.yaml
+++ b/setup-sandpaper/action.yaml
@@ -83,7 +83,7 @@ runs:
           sudo xargs apt-get install --fix-missing -y < ${{ runner.temp }}/sysdeps.txt || echo "Not on Ubuntu"
 
       - name: Restore R package cache
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.R_LIBS_USER }}/*

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -34,7 +34,7 @@ runs:
   using: "composite"
   steps:
       - name: "Restore {renv} Cache"
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: ${{ env.RENV_PATHS_ROOT }}
           key: ${{ runner.os }}-${{ inputs.cache-version }}-renv-${{ hashFiles('**/renv.lock') }}
@@ -120,7 +120,7 @@ runs:
           cat("::endgroup::\n")
 
       - name: "Upload renv folder as artifact (extract as renv/)"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: renv
           path: |


### PR DESCRIPTION
Fix `Node.js` warnings linked to GitHub actions: bump versions `actions/checkout@v4`, and `actions/upload-artifact@v4`

Fixes:
```
Update Workflow
Node.js 16 actions are deprecated.
Please update the following actions to use Node.js 20:
actions/checkout@v3, carpentries/create-pull-request@main.
For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

and
```
Build Full Site
The following actions use a deprecated Node.js version and will be forced to run on node20:
 actions/cache@v3.0.11.
 For more info:
 https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```

raised for example in:
https://github.com/carpentries-incubator/SDC-BIDS-fMRI/actions/runs/9753104282
and
https://github.com/carpentries-incubator/SDC-BIDS-IntroMRI/actions/runs/10578432348
