### PR TITLE
Fix r-universe URL and parsing for version, update docs

### DIFF
--- a/check-valid-credentials/README.md
+++ b/check-valid-credentials/README.md
@@ -59,7 +59,7 @@ jobs:
       - name: Create Pull Request
         id: cpr
         if: "${{ steps.update.outputs.new }}"
-        uses: peter-evans/create-pull-request@v3.10.0
+        uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.SANDPAPER_WORKFLOW }}
           delete-branch: true

--- a/update-workflows/README.md
+++ b/update-workflows/README.md
@@ -1,6 +1,6 @@
 # Update Sandpaper Workflows
 
-This action will update the workflow files from {sandopaper} and is designed to
+This action will update the workflow files from {sandpaper} and is designed to
 be triggered periodically or manually. 
 
 ## Inputs
@@ -22,11 +22,11 @@ Globbing pattern of files to remove before updating workflows
 
 ### `new`
 
-The new version of {sandpaper} the workflows have come from
+The new version of {sandpaper} the workflows have come from.
 
 ### `old`
 
-The previous version of {sandpaper} the workflows were at. 
+The previous version of {sandpaper} the workflows were at.
 
 ## Example usage
 
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Update Workflows
         id: update
@@ -54,7 +54,7 @@ jobs:
       - name: Create Pull Request
         id: cpr
         if: "${{ steps.update.outputs.new }}"
-        uses: peter-evans/create-pull-request@v3.10.0
+        uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.SANDPAPER_WORKFLOW }}
           delete-branch: true

--- a/update-workflows/update-workflows.sh
+++ b/update-workflows/update-workflows.sh
@@ -3,12 +3,12 @@ set -eo pipefail
 
 # Download and update sandpaper workflow files from an upstream repository
 #
-# usage: 
+# usage:
 #   bash update-workflows.sh [UPSTREAM] [SOURCE] [CLEAN]
 #
 # args:
 #   UPSTREAM - a version number from which to fetch the workflows. By default,
-#     this is fetched from https://carpentries.r-universe.dev/packages/sandpaper
+#     this is fetched from https://carpentries.r-universe.dev/api/packages/sandpaper
 #   SOURCE - a CRAN-like repository from which to fetch a tarball of sandpaper
 #     By default this is fetched from https://carpentries.r-universe.dev/
 #   CLEAN files to clean as a pattern. Example: *.yaml will clean all the yaml
@@ -35,8 +35,8 @@ CURRENT=$(cat .github/workflows/sandpaper-version.txt)
 
 # Fetch upstream version from the API if we don't have that information
 if [[ ${UPSTREAM} == 'current' ]]; then
-  UPSTREAM=$(curl -L ${SOURCE}/packages/sandpaper/)
-  UPSTREAM=$(echo ${UPSTREAM} | jq -r .[1].Version)
+  UPSTREAM=$(curl -L ${SOURCE}/api/packages/sandpaper/)
+  UPSTREAM=$(echo ${UPSTREAM} | jq -r .Version)
 elif [[ ${SOURCE} == 'https://carpentries.r-universe.dev' ]]; then
   SOURCE=https://carpentries.github.io/drat
 fi


### PR DESCRIPTION
This PR fixes #95 - the r-universe URL and JSON spec seem to have changed, so the `update-workflows.sh` was failing to get the latest upstream sandpaper version number.