### PR TITLE
Add shim to enable remotes (<= 2.5.0) support for ubuntu 24.04

### DIFF
--- a/setup-lesson-deps/action.yaml
+++ b/setup-lesson-deps/action.yaml
@@ -59,12 +59,12 @@ runs:
             rmts <- asNamespace("remotes")
             # extract the function
             sov <- rmts$supported_os_versions
-            # if 22.04 is not present, we need to modify the function
-            if (!grepl("22.04", body(sov)[2])) {
+            # if 24.04 is not present, we need to modify the function
+            if (!grepl("24.04", body(sov)[2])) {
               unlockBinding("supported_os_versions", rmts)
-              # modify the list in the body to include 22.04
+              # modify the list in the body to include 24.04
               vers <- eval(parse(text = as.character(body(sov)[2])))
-              vers$ubuntu <- c(vers$ubuntu, "22.04")
+              vers$ubuntu <- c(vers$ubuntu, "24.04")
               # replace the body
               body(sov)[2] <- list(str2lang(paste(capture.output(dput(vers)), collapse = "")))
               # replace the function in the namespace


### PR DESCRIPTION
Ubuntu 22.04 has been present in the official remotes version for 3 years now so it's probably safe to drop the hack for it here.

However, support for ubuntu 24.04 has not yet landed in the released version of remotes (see https://github.com/r-lib/remotes/pull/826) so I'm re-using the code already present to offer in the meantime.

Another alternative could be to drop this entire code chunk and add the remotes dev version to the Carpentries r-universe to get support for ubuntu 24.04 through "official" means.
