### PR TITLE
Fixes bash check to see whether the gitignore already includes renv/sandbox

### DIFF
--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -44,7 +44,7 @@ runs:
       - name: "Check for and/or update renv/sandbox ignore"
         shell: bash
         run: |
-          if [ $(grep 'renv/sandbox' .gitignore) ]; then
+          if grep -q 'renv/sandbox' .gitignore; then
             :
           else
             printf 'renv/sandbox\n' >> .gitignore


### PR DESCRIPTION
Prevents extra duplicate lines being added to the .gitignore file
