### PR TITLE
Add new validate org workflow

### DIFF
--- a/check-valid-credentials/validate.sh
+++ b/check-valid-credentials/validate.sh
@@ -3,11 +3,11 @@ set -eo pipefail
 
 # Download and update sandpaper workflow files from an upstream repository
 #
-# usage: 
+# usage:
 #   bash validate.sh GITHUB_PAT
 #
 # args:
-#   GITHUB_PAT a github personal access token. This is only ever used for 
+#   GITHUB_PAT a github personal access token. This is only ever used for
 #   accessing the headers of the /user/ endpoint of the github API
 #
 # Fail if we aren't in a sandpaper repository
@@ -33,11 +33,11 @@ echo "The \`SANDPAPER_WORKFLOW\` secret is missing, invalid, or does not" \
   "have the right scope (public_repo, workflow) to update the package cache." >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
 echo "If you want to have automated pull request updates to your package cache," \
-"you will need to generate a new token." >> $GITHUB_STEP_SUMMARY
+"you will need to generate a new Classic token." >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
-echo "### Steps to Generate a New Token" >> $GITHUB_STEP_SUMMARY
+echo "### Steps to Generate a New Classic Token" >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
-echo "1. :key: [Click here to generate a new token](${TOKEN_URL}) called \`Sandpaper Token (${GITHUB_REPOSITORY})\` with the "public_repo" and "workflow" scopes from your GitHub Account" >> $GITHUB_STEP_SUMMARY
+echo "1. :key: [Click here to generate a new Classic token](${TOKEN_URL}) called \`Sandpaper Token (${GITHUB_REPOSITORY})\` with the "public_repo" and "workflow" scopes from your GitHub Account" >> $GITHUB_STEP_SUMMARY
 echo "2. :clipboard: Copy your new token to your clipboard" >> $GITHUB_STEP_SUMMARY
 echo "3. Go To https://github.com/${GITHUB_REPOSITORY}/settings/secrets/actions/new" >> $GITHUB_STEP_SUMMARY
 echo "   - enter \`SANDPAPER_WORKFLOW\` for the 'Name'" >> $GITHUB_STEP_SUMMARY

--- a/hybrid-auth/README.md
+++ b/hybrid-auth/README.md
@@ -1,2 +1,13 @@
 # Hybrid Authentication
 
+This action is intended to check the Carpentries AWS Secrets Manager for PATs that can be used in workflows.
+
+This can only be called from a controlled set of repositories and branches.
+
+It is not intended for use outside the core Carpentries GitHub organisations.
+
+## Issues
+
+Due to GitHub's policy on masking secrets in outputs across jobs, this action does not work as intended as yet.
+
+It remains here in case GitHub changes this policy, and our main workflows can be simplified to use this reusable workflow.

--- a/hybrid-auth/README.md
+++ b/hybrid-auth/README.md
@@ -1,0 +1,2 @@
+# Hybrid Authentication
+

--- a/hybrid-auth/action.yaml
+++ b/hybrid-auth/action.yaml
@@ -6,6 +6,7 @@ inputs:
   org:
     description: 'GitHub organization name'
     required: true
+    default: 'carpentries'
   aws-region:
     description: 'AWS region where the secret lives'
     required: false
@@ -14,10 +15,6 @@ inputs:
     description: 'Secret name in AWS Secrets Manager'
     required: false
     default: 'carpentries-bot/github-pat'
-  fallback-secret:
-    description: 'Fallback repo secret for forks'
-    required: false
-    default: 'SANDPAPER_WORKFLOW'
 
 outputs:
   pat:
@@ -54,16 +51,8 @@ runs:
                     --query SecretString --output text)" >> "$GITHUB_OUTPUT"
         echo "::add-mask::$pat"
 
-    - name: Set PAT from fallback secret (forks only)
-      id: set-pat-fork
-      if: steps.fork.outputs.fork == 'true'
-      shell: bash
-      run: |
-        FALLBACK=${{ secrets[inputs.fallback-secret] }}
-        echo "pat=$FALLBACK" >> "$GITHUB_OUTPUT"
-        echo "::add-mask::$pat"
-
     - name: Export PAT for use in later steps
       shell: bash
+      if: steps.fork.outputs.fork == 'false'
       run: |
-        echo "SANDPAPER_WORKFLOW=${{ steps.set-pat.outputs.pat || steps.set-pat-fork.outputs.pat }}" >> "$GITHUB_ENV"
+        echo "SANDPAPER_WORKFLOW=${{ steps.set-pat.outputs.pat }}" >> "$GITHUB_ENV"

--- a/hybrid-auth/action.yaml
+++ b/hybrid-auth/action.yaml
@@ -36,7 +36,7 @@ runs:
 
     - name: Configure AWS credentials via OIDC (internal only)
       if: steps.fork.outputs.fork == 'false'
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v4.1.0
       with:
         role-skip-session-tagging: true
         role-to-assume: arn:aws:iam::860325783027:role/carpentries-github-oidc-auth
@@ -47,9 +47,11 @@ runs:
       if: steps.fork.outputs.fork == 'false'
       shell: bash
       run: |
-        echo "pat=$(aws secretsmanager get-secret-value \
-                    --secret-id ${{ inputs.aws-secret-id }} \
-                    --query SecretString --output text)" >> "$GITHUB_OUTPUT"
+        SECRET=$(aws secretsmanager get-secret-value \
+                 --secret-id ${{ inputs.aws-secret-id }} \
+                 --query SecretString --output text)
+        PAT=$(echo "$SECRET" | jq -r .github-pat)
+        echo "pat=$PAT" >> "$GITHUB_OUTPUT"
         echo "::add-mask::$pat"
 
     - name: Export PAT for use in later steps

--- a/hybrid-auth/action.yaml
+++ b/hybrid-auth/action.yaml
@@ -50,6 +50,6 @@ runs:
         SECRET=$(aws secretsmanager get-secret-value \
                  --secret-id ${{ inputs.aws-secret-id }} \
                  --query SecretString --output text)
-        PAT=$(echo "$SECRET" | jq -r .github-pat)
+        PAT=$(echo "$SECRET" | jq -r .[])
         echo "::add-mask::$PAT"
         echo "pat=$PAT" >> "$GITHUB_OUTPUT"

--- a/hybrid-auth/action.yaml
+++ b/hybrid-auth/action.yaml
@@ -1,0 +1,68 @@
+name: 'Hybrid GitHub Auth'
+description: >
+  Sets the SANDPAPER_WORKFLOW environment variable based on internal (OIDC+SecretsManager) or fork (repo secret) context.
+
+inputs:
+  org:
+    description: 'GitHub organization name'
+    required: true
+  aws-region:
+    description: 'AWS region where the secret lives'
+    required: false
+    default: 'us-east-1'
+  aws-secret-id:
+    description: 'Secret name in AWS Secrets Manager'
+    required: false
+    default: 'carpentries-bot/github-pat'
+  fallback-secret:
+    description: 'Fallback repo secret for forks'
+    required: false
+    default: 'SANDPAPER_WORKFLOW'
+
+outputs:
+  pat:
+    description: 'The resolved PAT for use in other steps'
+    value: ${{ steps.set-pat.outputs.pat }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Check if this is a fork
+      id: fork
+      shell: bash
+      run: |
+        if [[ "${{ github.repository_owner }}" != "${{ inputs.org }}" ]]; then
+          echo "fork=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "fork=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Configure AWS credentials via OIDC (internal only)
+      if: steps.fork.outputs.fork == 'false'
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::860325783027:role/carpentries-github-oidc-auth
+        aws-region: ${{ inputs.aws-region }}
+
+    - name: Set PAT from AWS Secrets Manager (internal only)
+      id: set-pat
+      if: steps.fork.outputs.fork == 'false'
+      shell: bash
+      run: |
+        echo "pat=$(aws secretsmanager get-secret-value \
+                    --secret-id ${{ inputs.aws-secret-id }} \
+                    --query SecretString --output text)" >> "$GITHUB_OUTPUT"
+        echo "::add-mask::$pat"
+
+    - name: Set PAT from fallback secret (forks only)
+      id: set-pat-fork
+      if: steps.fork.outputs.fork == 'true'
+      shell: bash
+      run: |
+        echo "pat=${{ secrets[inputs.fallback-secret] }}" >> "$GITHUB_OUTPUT"
+        echo "::add-mask::$pat"
+
+    - name: Export PAT for use in later steps
+      shell: bash
+      run: |
+        echo "SANDPAPER_WORKFLOW=${{ steps.set-pat.outputs.pat || steps.set-pat-fork.outputs.pat }}" >> "$GITHUB_ENV"

--- a/hybrid-auth/action.yaml
+++ b/hybrid-auth/action.yaml
@@ -2,10 +2,6 @@ name: 'Hybrid GitHub Auth'
 description: >
   Sets the SANDPAPER_WORKFLOW environment variable based on internal (OIDC+SecretsManager) or fork (repo secret) context.
 
-permissions:
-  id-token: write # OIDC permission required
-  contents: read
-
 inputs:
   org:
     description: 'GitHub organization name'

--- a/hybrid-auth/action.yaml
+++ b/hybrid-auth/action.yaml
@@ -59,7 +59,8 @@ runs:
       if: steps.fork.outputs.fork == 'true'
       shell: bash
       run: |
-        echo "pat=${{ secrets[inputs.fallback-secret] }}" >> "$GITHUB_OUTPUT"
+        FALLBACK=${{ secrets[inputs.fallback-secret] }}
+        echo "pat=$FALLBACK" >> "$GITHUB_OUTPUT"
         echo "::add-mask::$pat"
 
     - name: Export PAT for use in later steps

--- a/hybrid-auth/action.yaml
+++ b/hybrid-auth/action.yaml
@@ -38,6 +38,7 @@ runs:
       if: steps.fork.outputs.fork == 'false'
       uses: aws-actions/configure-aws-credentials@v4
       with:
+        role-skip-session-tagging: true
         role-to-assume: arn:aws:iam::860325783027:role/carpentries-github-oidc-auth
         aws-region: ${{ inputs.aws-region }}
 

--- a/hybrid-auth/action.yaml
+++ b/hybrid-auth/action.yaml
@@ -53,9 +53,3 @@ runs:
         PAT=$(echo "$SECRET" | jq -r .github-pat)
         echo "::add-mask::$PAT"
         echo "pat=$PAT" >> "$GITHUB_OUTPUT"
-
-    - name: Export PAT for use in later steps
-      shell: bash
-      if: steps.fork.outputs.fork == 'false'
-      run: |
-        echo "SANDPAPER_WORKFLOW=${{ steps.set-pat.outputs.pat }}" >> "$GITHUB_ENV"

--- a/hybrid-auth/action.yaml
+++ b/hybrid-auth/action.yaml
@@ -51,8 +51,8 @@ runs:
                  --secret-id ${{ inputs.aws-secret-id }} \
                  --query SecretString --output text)
         PAT=$(echo "$SECRET" | jq -r .github-pat)
+        echo "::add-mask::$PAT"
         echo "pat=$PAT" >> "$GITHUB_OUTPUT"
-        echo "::add-mask::$pat"
 
     - name: Export PAT for use in later steps
       shell: bash

--- a/hybrid-auth/action.yaml
+++ b/hybrid-auth/action.yaml
@@ -2,6 +2,10 @@ name: 'Hybrid GitHub Auth'
 description: >
   Sets the SANDPAPER_WORKFLOW environment variable based on internal (OIDC+SecretsManager) or fork (repo secret) context.
 
+permissions:
+  id-token: write # OIDC permission required
+  contents: read
+
 inputs:
   org:
     description: 'GitHub organization name'

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -59,13 +59,6 @@ runs:
             printf 'renv/sandbox\n' >> .gitignore
           fi
 
-      - name: "Restore {renv} Cache"
-        uses: actions/cache/restore@v4
-        id: restore-cache
-        with:
-          path: ${{ env.RENV_PATHS_ROOT }}
-          key: ${{ runner.os }}-${{ inputs.cache-version }}-renv-${{ hashFiles('**/renv.lock') }}
-
       - name: "Setup System Dependencies"
         shell: Rscript {0}
         run: |

--- a/validate-org-workflow/README.md
+++ b/validate-org-workflow/README.md
@@ -1,0 +1,36 @@
+# Validate Organisation and Workflow
+
+This action will check that the repository and workflow currently running is part of an allowed set of options.
+
+Its function is to ensure that we can skip steps in workflows if they are not part of this allowed set.
+
+## Usage
+
+Inputs available:
+
+- `repo` : The repository where the workflow is calling this action. This is typially passed from the calling workflow as `${{ github.repository }}`
+- `workflow` : The workflow that is calling this action. This is typically passed from the calling workflow as `${{ github.workflow }}`
+
+Allowed set:
+
+```
+ALLOWED_ORGS=(
+    "carpentries"
+    "swcarpentry"
+    "datacarpentry"
+    "librarycarpentry"
+    "carpentries-incubator"
+    "froggleston"
+)
+
+ALLOWED_WORKFLOWS=(
+    "02 Maintain: Check for Updated Packages"
+    "04 Maintain: Update Workflow Files"
+)
+```
+
+## Outputs
+
+`is_valid` : Set to `'true'` if the repository and workflow are within the allowed set.
+
+Any repo or workflow not in this set will return `'false'`

--- a/validate-org-workflow/action.yaml
+++ b/validate-org-workflow/action.yaml
@@ -26,6 +26,7 @@ runs:
           "datacarpentry"
           "librarycarpentry"
           "carpentries-incubator"
+          "froggleston"
         )
 
         ALLOWED_WORKFLOWS=(

--- a/validate-org-workflow/action.yaml
+++ b/validate-org-workflow/action.yaml
@@ -9,47 +9,48 @@ inputs:
     type: string
 
 outputs:
-  is_valid: ${{ steps.validate-org-workflow.outputs.is_valid }}
+  is_valid:
+    description: 'Is the organisation and workflow valid?'
+    value: ${{ steps.validate-org-workflow.outputs.is_valid }}
 
-jobs:
-  validate:
-    runs-on: ubuntu-latest
+runs:
+  using: "composite"
+  steps:
+    - name: "Validate Organisation and Workflow"
+      id: validate-org-workflow
+      run: |
+        ALLOWED_ORGS=(
+          "carpentries"
+          "swcarpentry"
+          "datacarpentry"
+          "librarycarpentry"
+          "carpentries-incubator"
+        )
 
-    steps:
-      - id: validate-org-workflow
-        run: |
-          ALLOWED_ORGS=(
-            "carpentries"
-            "swcarpentry"
-            "datacarpentry"
-            "librarycarpentry"
-            "carpentries-incubator"
-          )
+        ALLOWED_WORKFLOWS=(
+          "02 Maintain: Check for Updated Packages"
+        )
 
-          ALLOWED_WORKFLOWS=(
-            "02 Maintain: Check for Updated Packages"
-          )
+        REPO="${{ inputs.repo }}"
+        WORKFLOW="${{ inputs.workflow }}"
 
-          REPO="${{ inputs.repo }}"
-          WORKFLOW="${{ inputs.workflow }}"
-
-          ORG=$(echo "$REPO" | cut -d/ -f1)
-          for o in "${ALLOWED_ORGS[@]}"; do
-            if [[ "$ORG" == "$o" ]]; then
-              org_found=1
-              break
-            fi
-          done
-
-          for w in "${ALLOWED_WORKFLOWS[@]}"; do
-            if [[ "$WORKFLOW" == "$w" ]]; then
-              wf_found=1
-              break
-            fi
-          done
-
-          if [[ $org_found && $wf_found ]]; then
-            echo "is_valid=true" >> $GITHUB_OUTPUT
-          else
-            echo "is_valid=false" >> $GITHUB_OUTPUT
+        ORG=$(echo "$REPO" | cut -d/ -f1)
+        for o in "${ALLOWED_ORGS[@]}"; do
+          if [[ "$ORG" == "$o" ]]; then
+            org_found=1
+            break
           fi
+        done
+
+        for w in "${ALLOWED_WORKFLOWS[@]}"; do
+          if [[ "$WORKFLOW" == "$w" ]]; then
+            wf_found=1
+            break
+          fi
+        done
+
+        if [[ $org_found && $wf_found ]]; then
+          echo "is_valid=true" >> $GITHUB_OUTPUT
+        else
+          echo "is_valid=false" >> $GITHUB_OUTPUT
+        fi

--- a/validate-org-workflow/action.yaml
+++ b/validate-org-workflow/action.yaml
@@ -1,0 +1,55 @@
+name: Validate Org and Workflow
+
+on:
+  workflow_call:
+    inputs:
+      repo:
+        required: true
+        type: string
+      workflow:
+        required: true
+        type: string
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    outputs:
+      is_valid: ${{ steps.validate-org-workflow.outputs.is_valid }}
+    steps:
+      - id: validate-org-workflow
+        run: |
+          ALLOWED_ORGS=(
+            "carpentries"
+            "swcarpentry"
+            "datacarpentry"
+            "librarycarpentry"
+            "carpentries-incubator"
+          )
+
+          ALLOWED_WORKFLOWS=(
+            "02 Maintain: Check for Updated Packages"
+          )
+
+          REPO="${{ inputs.repo }}"
+          WORKFLOW="${{ inputs.workflow }}"
+
+          ORG=$(echo "$REPO" | cut -d/ -f1)
+          for o in "${ALLOWED_ORGS[@]}"; do
+            if [[ "$ORG" == "$o" ]]; then
+              org_found=1
+              break
+            fi
+          done
+
+          for w in "${ALLOWED_WORKFLOWS[@]}"; do
+            if [[ "$WORKFLOW" == "$w" ]]; then
+              wf_found=1
+              break
+            fi
+          done
+
+          if [[ $org_found && $wf_found ]]; then
+            echo "is_valid=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_valid=false" >> $GITHUB_OUTPUT
+          fi

--- a/validate-org-workflow/action.yaml
+++ b/validate-org-workflow/action.yaml
@@ -18,6 +18,7 @@ runs:
   steps:
     - name: "Validate Organisation and Workflow"
       id: validate-org-workflow
+      shell: bash
       run: |
         ALLOWED_ORGS=(
           "carpentries"

--- a/validate-org-workflow/action.yaml
+++ b/validate-org-workflow/action.yaml
@@ -31,6 +31,7 @@ runs:
 
         ALLOWED_WORKFLOWS=(
           "02 Maintain: Check for Updated Packages"
+          "04 Maintain: Update Workflow Files"
         )
 
         REPO="${{ inputs.repo }}"

--- a/validate-org-workflow/action.yaml
+++ b/validate-org-workflow/action.yaml
@@ -1,20 +1,20 @@
 name: Validate Org and Workflow
 
-on:
-  workflow_call:
-    inputs:
-      repo:
-        required: true
-        type: string
-      workflow:
-        required: true
-        type: string
+inputs:
+  repo:
+    required: true
+    type: string
+  workflow:
+    required: true
+    type: string
+
+outputs:
+  is_valid: ${{ steps.validate-org-workflow.outputs.is_valid }}
 
 jobs:
   validate:
     runs-on: ubuntu-latest
-    outputs:
-      is_valid: ${{ steps.validate-org-workflow.outputs.is_valid }}
+
     steps:
       - id: validate-org-workflow
         run: |


### PR DESCRIPTION
This PR adds two new workflows, one of which is active, one is not.

- `validate-org-workflow` action to check if a workflow is running in a core Carpentries org
- `hybrid-auth` action to pull PATs from AWS Secrets Manager (not working at present due to GitHub secret masking policies across jobs and workflows)