### PR TITLE
Add workflow update error handling, revert checkout to v5 for l10n

### DIFF
--- a/build-and-deploy/action.yaml
+++ b/build-and-deploy/action.yaml
@@ -29,6 +29,8 @@ runs:
       uses: actions/checkout@v6
       with:
         ref: l10n_main
+        persist-credentials: true
+        token: ${{ inputs.token }}
 
     - name: Set up translation
       id: setup-translation

--- a/build-and-deploy/action.yaml
+++ b/build-and-deploy/action.yaml
@@ -16,9 +16,6 @@ inputs:
     description: 'Language code for translation (e.g. "en", "es", "fr"). Defaults to "".'
     required: false
     default: ''
-  token:
-    description: "GH Token"
-    required: true
 
 runs:
   using: "composite"
@@ -26,11 +23,9 @@ runs:
   steps:
     - name: Checkout l10n_main branch
       if: ${{ inputs.lang-code != '' }}
-      uses: actions/checkout@v6
+      uses: actions/checkout@v5
       with:
         ref: l10n_main
-        persist-credentials: true
-        token: ${{ inputs.token }}
 
     - name: Set up translation
       id: setup-translation
@@ -47,8 +42,6 @@ runs:
 
     - name: Run Container and Build Site
       id: build-and-deploy
-      env:
-        GITHUB_TOKEN: ${{ inputs.token }}
       run: |
         library(sandpaper)
         reset <- "${{ inputs.reset }}" == "true"

--- a/build-and-deploy/action.yaml
+++ b/build-and-deploy/action.yaml
@@ -16,9 +16,13 @@ inputs:
     description: 'Language code for translation (e.g. "en", "es", "fr"). Defaults to "".'
     required: false
     default: ''
+  token:
+    description: "GH Token"
+    required: true
 
 runs:
   using: "composite"
+
   steps:
     - name: Checkout l10n_main branch
       if: ${{ inputs.lang-code != '' }}
@@ -41,6 +45,8 @@ runs:
 
     - name: Run Container and Build Site
       id: build-and-deploy
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
       run: |
         library(sandpaper)
         reset <- "${{ inputs.reset }}" == "true"

--- a/update-workflows/update-workflows.sh
+++ b/update-workflows/update-workflows.sh
@@ -62,6 +62,7 @@ if [[ ${UPSTREAM} == 'latest' ]]; then
   if [[ ${UPSTREAM} == "null" ]]; then
     ERROR_CODE=$(echo "${INFO}" | jq -r .status)
     ERROR_MESSAGE=$(echo "${INFO}" | jq -r .message)
+    echo "::error::Unable to resolve latest release tag from GitHub API."
     echo "::error::Unable to resolve latest release tag from GitHub API." >> $GITHUB_STEP_SUMMARY
     echo "" >> $GITHUB_STEP_SUMMARY
     echo "Status: ${ERROR_CODE}" >> $GITHUB_STEP_SUMMARY
@@ -82,6 +83,7 @@ else
   if [[ ${SHA} == "null" ]]; then
     ERROR_CODE=$(echo "${INFO}" | jq -r .status)
     ERROR_MESSAGE=$(echo "${INFO}" | jq -r .message)
+    echo "::error::Unable to resolve branch '${UPSTREAM}' from GitHub API."
     echo "::error::Unable to resolve branch '${UPSTREAM}' from GitHub API." >> $GITHUB_STEP_SUMMARY
     echo "" >> $GITHUB_STEP_SUMMARY
     echo "Status: ${ERROR_CODE}" >> $GITHUB_STEP_SUMMARY

--- a/update-workflows/update-workflows.sh
+++ b/update-workflows/update-workflows.sh
@@ -57,17 +57,39 @@ echo "::endgroup::"
 
 if [[ ${UPSTREAM} == 'latest' ]]; then
   # resolve latest release
-  INFO=$(curl -s https://api.github.com/repos/carpentries/workbench-workflows/releases/${UPSTREAM})
-  UPSTREAM=$(echo ${INFO} | jq -r .tag_name)
-  BODY=$(echo ${INFO} | jq -r .body)
+  INFO=$(curl -s -H "Accept: application/json" https://api.github.com/repos/carpentries/workbench-workflows/releases/${UPSTREAM})
+  UPSTREAM=$(echo "${INFO}" | jq -r .tag_name)
+  if [[ ${UPSTREAM} == "null" ]]; then
+    ERROR_CODE=$(echo "${INFO}" | jq -r .status)
+    ERROR_MESSAGE=$(echo "${INFO}" | jq -r .message)
+    echo "::error::Unable to resolve latest release tag from GitHub API." >> $GITHUB_STEP_SUMMARY
+    echo "" >> $GITHUB_STEP_SUMMARY
+    echo "Status: ${ERROR_CODE}" >> $GITHUB_STEP_SUMMARY
+    echo "Message: ${ERROR_MESSAGE}" >> $GITHUB_STEP_SUMMARY
+    echo "" >> $GITHUB_STEP_SUMMARY
+    echo "Please re-run this workflow!" >> $GITHUB_STEP_SUMMARY
+    exit 1
+  fi
+  BODY=$(echo "${INFO}" | jq -r .body)
   SOURCE="${WF_REPO}/tags/${UPSTREAM}.tar.gz"
 elif [[ ${UPSTREAM} =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
   # if input matches version number
   SOURCE="${WF_REPO}/tags/${UPSTREAM}.tar.gz"
 else
   # assume branch name
-  INFO=$(curl -s https://api.github.com/repos/carpentries/workbench-workflows/branches/${UPSTREAM})
+  INFO=$(curl -s -H "Accept: application/json" https://api.github.com/repos/carpentries/workbench-workflows/branches/${UPSTREAM})
   SHA=$(echo ${INFO} | jq -r .commit.sha)
+  if [[ ${SHA} == "null" ]]; then
+    ERROR_CODE=$(echo "${INFO}" | jq -r .status)
+    ERROR_MESSAGE=$(echo "${INFO}" | jq -r .message)
+    echo "::error::Unable to resolve branch '${UPSTREAM}' from GitHub API." >> $GITHUB_STEP_SUMMARY
+    echo "" >> $GITHUB_STEP_SUMMARY
+    echo "Status: ${ERROR_CODE}" >> $GITHUB_STEP_SUMMARY
+    echo "Message: ${ERROR_MESSAGE}" >> $GITHUB_STEP_SUMMARY
+    echo "" >> $GITHUB_STEP_SUMMARY
+    echo "Please re-run this workflow with a valid branch name for the carpentries/workbench-workflows repository." >> $GITHUB_STEP_SUMMARY
+    exit 1
+  fi
   BODY=$(curl -s https://api.github.com/repos/carpentries/workbench-workflows/git/commits/${SHA} | jq -r .message)
   SOURCE="${WF_REPO}/heads/${UPSTREAM}.tar.gz"
 fi


### PR DESCRIPTION
This PR reverts the build-and-deploy workflow checkout action to v5 in the specific case where a LANG_CODE is supplied. When using checkout v6, this breaks the git auth process for non-default branches, which would be l10n_main in this case. When v6 is suitable in future, this will get bumped.

This also adds error handling for the rare case where the GitHub API fails for getting the latest release/tag/a specific branch for workflow updates.