### PR TITLE
Fix config lang issue when using l10n_main

### DIFF
--- a/build-and-deploy/action.yaml
+++ b/build-and-deploy/action.yaml
@@ -36,8 +36,16 @@ runs:
         dovetail:::make_translated_dir(
           translated_dir = "${{ runner.temp }}", overwrite = TRUE, lang = lang_code, l10n_branch = NULL, clean = FALSE
         )
+        withr::with_dir(
+          ${{ runner.temp }},
+          {
+            conf <- yaml::read_yaml("config.yaml")
+            conf$lang <- lang_code
+            yaml::write_yaml(conf, "config.yaml")
+          }
+        )
         cat("build_path=${{ runner.temp }}\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
-        cat("Using translated lesson directory at: ${{ runner.temp }}\n")
+        cat("Using lang ${{ inputs.lang_code }} translated lesson directory at: ${{ runner.temp }}\n")
       shell: Rscript {0}
 
     - name: Run Container and Build Site

--- a/build-and-deploy/action.yaml
+++ b/build-and-deploy/action.yaml
@@ -37,7 +37,7 @@ runs:
           translated_dir = "${{ runner.temp }}", overwrite = TRUE, lang = lang_code, l10n_branch = NULL, clean = FALSE
         )
         withr::with_dir(
-          ${{ runner.temp }},
+          "${{ runner.temp }}",
           {
             conf <- yaml::read_yaml("config.yaml")
             conf$lang <- lang_code

--- a/build-and-deploy/action.yaml
+++ b/build-and-deploy/action.yaml
@@ -45,7 +45,7 @@ runs:
           }
         )
         cat("build_path=${{ runner.temp }}\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
-        cat("Using lang ${{ inputs.lang_code }} translated lesson directory at: ${{ runner.temp }}\n")
+        cat("Using lang ${{ inputs.lang-code }} translated lesson directory at: ${{ runner.temp }}\n")
       shell: Rscript {0}
 
     - name: Run Container and Build Site


### PR DESCRIPTION
For some reason, if the config.yaml has a `lang` setting to something other than "en", when using the l10n_main translation setup with dovetail this lang setting is either overridden or the config.yaml is pulled from main instead (I haven't figured out which).

As such, this forces the lang in the l10n_main branch config.yaml to the lang-code passed as input.