### PR TITLE
Use renv profile library in update-lockfile

### DIFF
--- a/setup-lesson-deps/action.yaml
+++ b/setup-lesson-deps/action.yaml
@@ -51,11 +51,20 @@ runs:
               install.packages(pkg, ...)
             }
           }
+
           wd <- '${{ github.workspace }}'
           has_lock <- file.exists(file.path(wd, 'renv'))
           if (Sys.info()[["sysname"]] == "Linux" && has_lock) {
+            Sys.setenv("RENV_PROFILE" = "lesson-requirements")
+
             req("renv")
-            req("remotes")
+            lib  <- renv::paths$library()
+            if (!dir.exists(lib)) {
+              dir.create(lib, recursive = TRUE, showWarnings = FALSE)
+            }
+            .libPaths(c(lib, .libPaths()))
+
+            req("remotes", lib = lib)
             rmts <- asNamespace("remotes")
             # extract the function
             sov <- rmts$supported_os_versions
@@ -70,12 +79,12 @@ runs:
               # replace the function in the namespace
               rmts$supported_os_versions <- sov
             }
-            req("desc")
-            remotes::install_github("carpentries/vise")
+            req("desc", lib = lib)
+            remotes::install_github("carpentries/vise", lib = lib)
             if (file.exists("DESCRIPTION")) {
               file.rename("DESCRIPTION", "DESCRIPTION.bak")
             }
-            Sys.setenv("RENV_PROFILE" = "lesson-requirements")
+
             Sys.setenv("RSPM_ROOT" = "https://packagemanager.posit.co")
             vise::lock2desc(renv::paths$lockfile(), desc = "${{ github.workspace }}/DESCRIPTION")
             writeLines(readLines("${{ github.workspace }}/DESCRIPTION"))
@@ -109,13 +118,9 @@ runs:
           # Fortify local {renv} packages
           cat("::group::Fortify local {renv} packages\n")
           wd <- '${{ github.workspace }}'
-          req <- function(pkg) {
+          req <- function(pkg, ...) {
             if (!requireNamespace(pkg, quietly = TRUE))
-              install.packages(pkg)
-          }
-          if (file.exists("DESCRIPTION")) {
-            req("remotes")
-            remotes::install_deps()
+              install.packages(pkg, ...)
           }
           cat("::endgroup::\n")
           if (file.exists(file.path(wd, 'renv'))) {
@@ -127,6 +132,14 @@ runs:
             }
             req("renv")
             Sys.setenv("RENV_PROFILE" = "lesson-requirements")
+            lib  <- renv::paths$library()
+            .libPaths(c(lib, .libPaths()))
+
+            if (file.exists("DESCRIPTION")) {
+              req("remotes", lib = lib)
+              remotes::install_deps(lib = lib)
+            }
+
             tryCatch(sandpaper::manage_deps(path = wd, quiet = FALSE),
               error = function(e) {
                 iss <- "https://github.com/rstudio/renv/issues/1184"
@@ -135,6 +148,10 @@ runs:
             })
             cat("::endgroup::\n")
           } else {
+            if (file.exists("DESCRIPTION")) {
+              req("remotes")
+              remotes::install_deps()
+            }
             writeLines("Package cache not used")
           }
 

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -69,9 +69,12 @@ runs:
           wd <- '${{ github.workspace }}'
           has_lock <- file.exists(file.path(wd, 'renv'))
           if (Sys.info()[["sysname"]] == "Linux" && has_lock) {
+            Sys.setenv("RENV_PROFILE" = "lesson-requirements")
+
             req("renv")
             req("remotes")
             rmts <- asNamespace("remotes")
+
             # extract the function
             sov <- rmts$supported_os_versions
             # if 24.04 is not present, we need to modify the function
@@ -87,7 +90,6 @@ runs:
             }
             req("desc")
             remotes::install_github("carpentries/vise@frog-hydra-1")
-            Sys.setenv("RENV_PROFILE" = "lesson-requirements")
             Sys.setenv("RSPM_ROOT" = "https://packagemanager.posit.co")
             vise::ci_sysreqs(renv::paths$lockfile(), execute = TRUE)
           }

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -86,7 +86,7 @@ runs:
               rmts$supported_os_versions <- sov
             }
             req("desc")
-            remotes::install_github("carpentries/vise@main")
+            remotes::install_github("carpentries/vise@frog-hydra-1")
             Sys.setenv("RENV_PROFILE" = "lesson-requirements")
             Sys.setenv("RSPM_ROOT" = "https://packagemanager.posit.co")
             vise::ci_sysreqs(renv::paths$lockfile(), execute = TRUE)

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -76,6 +76,7 @@ runs:
             if (!dir.exists(lib)) {
               dir.create(lib, recursive = TRUE, showWarnings = FALSE)
             }
+            .libPaths(c(lib, .libPaths()))
 
             req("remotes", lib = lib)
             rmts <- asNamespace("remotes")

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -95,7 +95,7 @@ runs:
               rmts$supported_os_versions <- sov
             }
             req("desc", lib = lib)
-            remotes::install_github("carpentries/vise@frog-hydra-1", lib = lib)
+            remotes::install_github("carpentries/vise", lib = lib)
             Sys.setenv("RSPM_ROOT" = "https://packagemanager.posit.co")
             vise::ci_sysreqs(renv::paths$lockfile(), execute = TRUE)
           }

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -73,6 +73,9 @@ runs:
 
             req("renv")
             lib  <- renv::paths$library()
+            if (!dir.exists(lib)) {
+              dir.create(lib, recursive = TRUE, showWarnings = FALSE)
+            }
 
             req("remotes", lib = lib)
             rmts <- asNamespace("remotes")

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -95,7 +95,7 @@ runs:
               rmts$supported_os_versions <- sov
             }
             req("desc", lib = lib)
-            remotes::install_github("carpentries/vise@frog-hydra-1")
+            remotes::install_github("carpentries/vise@frog-hydra-1", lib = lib)
             Sys.setenv("RSPM_ROOT" = "https://packagemanager.posit.co")
             vise::ci_sysreqs(renv::paths$lockfile(), execute = TRUE)
           }

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -62,7 +62,7 @@ runs:
       - name: "Setup System Dependencies"
         shell: Rscript {0}
         run: |
-          req <- function(pkg, lib = .libPaths()) {
+          req <- function(pkg, lib = NULL) {
             if (!requireNamespace(pkg, quietly = TRUE))
             install.packages(pkg, repos = c("https://carpentries.r-universe.dev", "https://cran.rstudio.com"), lib = lib)
           }

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -106,6 +106,10 @@ runs:
         run: |
           # Verify inputs ------------------------------------------------------
           cat("::group::Verifying inputs and setting repositories\n")
+          Sys.setenv("RENV_PROFILE" = "lesson-requirements")
+          lib  <- renv::paths$library()
+          .libPaths(c(lib, .libPaths()))
+
           library(vise)
           vise::verify_simple_vector(${{ inputs.repos }})
           options(repos = ${{ inputs.repos }})

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -62,9 +62,9 @@ runs:
       - name: "Setup System Dependencies"
         shell: Rscript {0}
         run: |
-          req <- function(pkg) {
+          req <- function(pkg, lib = .libPaths()) {
             if (!requireNamespace(pkg, quietly = TRUE))
-            install.packages(pkg, repos = c("https://carpentries.r-universe.dev", "https://cran.rstudio.com"))
+            install.packages(pkg, repos = c("https://carpentries.r-universe.dev", "https://cran.rstudio.com"), lib = lib)
           }
           wd <- '${{ github.workspace }}'
           has_lock <- file.exists(file.path(wd, 'renv'))
@@ -72,7 +72,9 @@ runs:
             Sys.setenv("RENV_PROFILE" = "lesson-requirements")
 
             req("renv")
-            req("remotes")
+            lib  <- renv::paths$library()
+
+            req("remotes", lib = lib)
             rmts <- asNamespace("remotes")
 
             # extract the function
@@ -88,7 +90,7 @@ runs:
               # replace the function in the namespace
               rmts$supported_os_versions <- sov
             }
-            req("desc")
+            req("desc", lib = lib)
             remotes::install_github("carpentries/vise@frog-hydra-1")
             Sys.setenv("RSPM_ROOT" = "https://packagemanager.posit.co")
             vise::ci_sysreqs(renv::paths$lockfile(), execute = TRUE)


### PR DESCRIPTION
For some reason, the runner gets confused over which library packages are installed in. This didn't used to be a problem.

After renv is installed in the system library, this PR forces the renv setup of update-lockfile to use the lesson renv path (created if not existing) for subsequent installation/hydration/restoring.