### PR TITLE
Unset auth header set by checkout

### DIFF
--- a/update-workflows/action.yml
+++ b/update-workflows/action.yml
@@ -33,3 +33,7 @@ runs:
           ${{ inputs.version }} \
           ${{ inputs.clean }}
       shell: bash
+
+    - name: "Unset checkout auth"
+      run: git config --unset-all http.https://github.com/.extraheader
+      shell: bash


### PR DESCRIPTION
The checkout v6 action persists the auth token header, leading to double headers, and the workflow will fail.

This PR adds a step to the update-workflows action to forcibly remove the extra header.
