### PR TITLE
Remove renv check in docker version update

### DIFF
--- a/container-version/action.yaml
+++ b/container-version/action.yaml
@@ -104,7 +104,7 @@ runs:
       id: trigger-cache-update
       run: |
         # Compare current and last workbench versions #
-        if [[ ${{ inputs.renv-needed }} == 'true' && ${{ steps.wb-vers.outputs.container-version != steps.prev-wb-vers.outputs.last-build-container-version }} == 'true' ]]; then
+        if [[ ${{ steps.wb-vers.outputs.container-version != steps.prev-wb-vers.outputs.last-build-container-version }} == 'true' ]]; then
           echo "## 💡 New Workbench version available" >> $GITHUB_STEP_SUMMARY
           echo "A new Docker version of the Workbench has been detected since the last build." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
The Workbench docker update check shouldn't mandate renv to be present - the cache apply step already checks for this when it is then triggered by a successful Workbench docker update.