### PR TITLE
Only use github token in workflow update if set

### DIFF
--- a/check-valid-credentials/validate.sh
+++ b/check-valid-credentials/validate.sh
@@ -28,10 +28,10 @@ TOKEN_NAME="Sandpaper%20Token%20%28${GITHUB_REPOSITORY}%29"
 TOKEN_URL="https://github.com/settings/tokens/new?scopes=public_repo,workflow&description=${TOKEN_NAME}"
 
 # Set up output first
-echo "## ℹ️ Using Default GitHub Access Token" >> $GITHUB_STEP_SUMMARY
+echo "## ℹ️ Warning: Personal Access Token Required" >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
-echo "This lesson will use the default access token supplied by GitHub (\`secrets.GITHUB_TOKEN\`)." >> $GITHUB_STEP_SUMMARY
-echo "When using the Dockerised workflows released as part of {sandpaper} 0.18.0 or later, this will not affect the running of these workflows." >> $GITHUB_STEP_SUMMARY
+echo "Your repository needs a personal access token (PAT) to perform required Workbench workflow actions." >> $GITHUB_STEP_SUMMARY
+echo "If your repository is under your own GitHub user account or a non-Carpentries organisation, please follow the instructions below to create and configure a PAT." >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
 echo "If you have recently created this repository or changed any repository settings, and are experiencing any problems with building your lesson:" >> $GITHUB_STEP_SUMMARY
 echo "- please verify that you have checked the \`Allow GitHub Actions to create and approve pull requests\` checkbox in your [repository \`Workflow permissions\` settings](https://github.com/${GITHUB_REPOSITORY}/settings/actions)" >> $GITHUB_STEP_SUMMARY
@@ -54,7 +54,7 @@ if [[ ${PAT} ]]
 then
 
   headerfile=${TMP}/${RANDOM}
-  curl --dump-header ${headerfile} --head -H "Authorization: token ${PAT}" \
+  curl --dump-header ${headerfile} --head -H "Authorization: Bearer ${PAT}" \
     https://api.github.com/user > /dev/null
 
   WORKFLOW=$(grep -ic 'x-oauth-scopes: .*workflow' ${headerfile} || echo '0')

--- a/update-workflows/action.yml
+++ b/update-workflows/action.yml
@@ -4,11 +4,11 @@ inputs:
   version:
     description: "Version of workbench-workflows to use. 'latest' for latest release, a specific version tag (e.g. '0.0.1'), or a branch name (e.g. 'main')."
     required: false
-    default: 'latest'
+    default: "latest"
   clean:
     description: "Workflow file extensions to be cleaned before update. No wildcards as they will be auto-expanded. Defaults to none."
     required: false
-    default: '.yaml'
+    default: "".yaml"
   repo:
     description: "DEPRECATED: CRAN-like repository to get the workflow files (no slash at end)"
     required: false
@@ -16,6 +16,7 @@ inputs:
   token:
     description: "GitHub PAT, usually passed as 'secrets.GITHUB_TOKEN' from the caller workflow."
     required: false
+    default: ""
 
 outputs:
   old:

--- a/update-workflows/update-workflows.sh
+++ b/update-workflows/update-workflows.sh
@@ -55,9 +55,17 @@ echo "Requested version: ${UPSTREAM}"
 echo "Clean:             ${CLEAN}"
 echo "::endgroup::"
 
+GHTOKEN_HEADER=""
+if [[ ${GITHUB_TOKEN} ]]; then
+  echo "::notice::Using provided GITHUB_TOKEN for API requests."
+  GHTOKEN_HEADER="Authorization: Bearer ${GITHUB_TOKEN}"
+else
+  echo "::notice::No GITHUB_TOKEN provided. API requests may be rate limited."
+fi
+
 if [[ ${UPSTREAM} == 'latest' ]]; then
   # resolve latest release
-  INFO=$(curl -s -H "Accept: application/json" -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/carpentries/workbench-workflows/releases/${UPSTREAM})
+  INFO=$(curl -s -H "Accept: application/json" -H "${GHTOKEN_HEADER}" https://api.github.com/repos/carpentries/workbench-workflows/releases/${UPSTREAM})
   UPSTREAM=$(echo "${INFO}" | jq -r .tag_name)
   if [[ ${UPSTREAM} == "null" ]]; then
     ERROR_CODE=$(echo "${INFO}" | jq -r .status)
@@ -78,7 +86,7 @@ elif [[ ${UPSTREAM} =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
   SOURCE="${WF_REPO}/tags/${UPSTREAM}.tar.gz"
 else
   # assume branch name
-  INFO=$(curl -s -H "Accept: application/json" -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/carpentries/workbench-workflows/branches/${UPSTREAM})
+  INFO=$(curl -s -H "Accept: application/json" -H "${GHTOKEN_HEADER}" https://api.github.com/repos/carpentries/workbench-workflows/branches/${UPSTREAM})
   SHA=$(echo ${INFO} | jq -r .commit.sha)
   if [[ ${SHA} == "null" ]]; then
     ERROR_CODE=$(echo "${INFO}" | jq -r .status)
@@ -92,7 +100,7 @@ else
     echo "Please re-run this workflow with a valid branch name for the carpentries/workbench-workflows repository." >> $GITHUB_STEP_SUMMARY
     exit 1
   fi
-  BODY=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/carpentries/workbench-workflows/git/commits/${SHA} | jq -r .message)
+  BODY=$(curl -s -H "${GHTOKEN_HEADER}" https://api.github.com/repos/carpentries/workbench-workflows/git/commits/${SHA} | jq -r .message)
   SOURCE="${WF_REPO}/heads/${UPSTREAM}.tar.gz"
 fi
 


### PR DESCRIPTION
Before next workflow release, we need a check for the token header rather than including a blank token which will result in authentication failures.

Also update the step summary message when no PAT (or incorrect PAT permissions) is set.
