### PR TITLE
PR check to ignore files in .github but aren't yaml

### DIFF
--- a/check-valid-pr/index.js
+++ b/check-valid-pr/index.js
@@ -30,7 +30,15 @@ async function run() {
   }
 
   function isNotWorkflow(l) {
-    return !l.startsWith('.github/');
+    return (
+      // check that the file is not in the .github directory
+      !l.startsWith('.github/') ||
+      // or check that the file is, but is not a workflow file, e.g. a issue/PR template
+      (
+        l.startsWith('.github/') &&
+        !l.endsWith('.yaml') && !l.endsWith('.yml')
+      )
+    );
   }
 
   // STEP 1: Access Pull Request -----------------------------------------------


### PR DESCRIPTION
Currently, this check will return invalid even if non-malicious files are changed in the `.github` folder, e.g. issue and PR template markdown files.

This PR allows files that aren't yaml/yml to pass this filter.
