### PR TITLE
Add support to install from GitHub source, add yaml import

### DIFF
--- a/build-container-deps/action.yaml
+++ b/build-container-deps/action.yaml
@@ -123,9 +123,24 @@ runs:
 
           cat(paste0(pak::repo_status()$name, " ", pak::repo_status()$url))
 
-          sys_reqs <- pak::pkg_sysreqs(pkgs, upgrade = FALSE, dependencies = NA)
-          if (length(sys_reqs$install_scripts)) {
-            system(sys_reqs$install_scripts)
+          sysreq_pkgs <- vapply(pkgs, function(pkg) {
+            if (identical(lock$Packages[[pkg]]$Source, "GitHub")) {
+              remote_ref <- lock$Packages[[pkg]]$RemotePkgRef
+              if (!is.null(remote_ref) && nzchar(remote_ref)) {
+                return(remote_ref)
+              }
+            }
+            pkg
+          }, character(1), USE.NAMES = FALSE)
+          sysreq_pkgs <- unique(sysreq_pkgs)
+
+          if (length(sysreq_pkgs)) {
+            sys_reqs <- pak::pkg_sysreqs(sysreq_pkgs, upgrade = FALSE, dependencies = NA)
+            if (length(sys_reqs$install_scripts)) {
+              system(sys_reqs$install_scripts)
+            }
+          } else {
+            cat("No packages require sysreq resolution.\n")
           }
         }
 

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -71,6 +71,7 @@ runs:
           if (Sys.info()[["sysname"]] == "Linux" && has_lock) {
             Sys.setenv("RENV_PROFILE" = "lesson-requirements")
 
+            req("yaml")
             req("renv")
             lib  <- renv::paths$library()
             if (!dir.exists(lib)) {

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -96,7 +96,7 @@ runs:
               rmts$supported_os_versions <- sov
             }
             req("desc", lib = lib)
-            remotes::install_github("carpentries/vise@frog-yaml-dep-1", lib = lib)
+            remotes::install_github("carpentries/vise", lib = lib)
             Sys.setenv("RSPM_ROOT" = "https://packagemanager.posit.co")
             vise::ci_sysreqs(renv::paths$lockfile(), execute = TRUE)
           }

--- a/update-lockfile/action.yaml
+++ b/update-lockfile/action.yaml
@@ -96,7 +96,7 @@ runs:
               rmts$supported_os_versions <- sov
             }
             req("desc", lib = lib)
-            remotes::install_github("carpentries/vise", lib = lib)
+            remotes::install_github("carpentries/vise@frog-yaml-dep-1", lib = lib)
             Sys.setenv("RSPM_ROOT" = "https://packagemanager.posit.co")
             vise::ci_sysreqs(renv::paths$lockfile(), execute = TRUE)
           }


### PR DESCRIPTION
`vise` and the `update-lockfile` action work to install any system dependencies. This previously assumed that all packages would be available through CRAN or RSPM. However, GitHub source packages are also valid, so this PR:

- keeps the current mechanism of passing the package name when from a repository
- adds support to pass the package `RemotePkgRef` when the package has a Source of "GitHub"