### PR TITLE
Fail on build based on cache failure

### DIFF
--- a/build-container-deps/action.yaml
+++ b/build-container-deps/action.yaml
@@ -124,9 +124,11 @@ runs:
           cat(paste0(pak::repo_status()$name, " ", pak::repo_status()$url))
 
           sysreq_pkgs <- vapply(pkgs, function(pkg) {
+            cat(capture.output(lock$Packages[[pkg]]), sep = "\n")
             if (identical(lock$Packages[[pkg]]$Source, "GitHub")) {
               remote_ref <- lock$Packages[[pkg]]$RemotePkgRef
               if (!is.null(remote_ref) && nzchar(remote_ref)) {
+                cat("Using GitHub ref for", pkg, ":", remote_ref, "\n")
                 return(remote_ref)
               }
             }

--- a/build-preflight/action.yaml
+++ b/build-preflight/action.yaml
@@ -86,6 +86,7 @@ runs:
                 echo "## ⛔ Build Skipped" >> $GITHUB_STEP_SUMMARY
                 echo "Apply Cache workflow required but failed. No build will run." >> $GITHUB_STEP_SUMMARY
                 echo "push_or_pr=false" >> $GITHUB_OUTPUT
+                exit 1
               else
                 echo "✅ PR merged successfully. Build will run."
                 echo "push_or_pr=true" >> $GITHUB_OUTPUT
@@ -98,11 +99,10 @@ runs:
                     "${{ steps.get-apply-cache-result.outputs.apply_cache_result }}" != "true"
                   ) ]]; then
               echo "⛔ Apply Cache workflow required but failed. No build will run."
-
               echo "## ⛔ Build Skipped" >> $GITHUB_STEP_SUMMARY
               echo "Apply Cache workflow required but failed. No build will run." >> $GITHUB_STEP_SUMMARY
-
               echo "push_or_pr=false" >> $GITHUB_OUTPUT
+              exit 1
             else
               echo "✅ Triggered from workflow run. Build will run."
               echo "push_or_pr=true" >> $GITHUB_OUTPUT

--- a/build-preflight/action.yaml
+++ b/build-preflight/action.yaml
@@ -85,6 +85,8 @@ runs:
                 echo "⛔ Apply Cache workflow required but failed. No build will run."
                 echo "## ⛔ Build Skipped" >> $GITHUB_STEP_SUMMARY
                 echo "Apply Cache workflow required but failed. No build will run." >> $GITHUB_STEP_SUMMARY
+                echo "" >> $GITHUB_STEP_SUMMARY
+                echo "Please run the 03 Maintain: Apply Package Cache manually to build a valid renv cache." >> $GITHUB_STEP_SUMMARY
                 echo "push_or_pr=false" >> $GITHUB_OUTPUT
                 exit 1
               else
@@ -101,6 +103,8 @@ runs:
               echo "⛔ Apply Cache workflow required but failed. No build will run."
               echo "## ⛔ Build Skipped" >> $GITHUB_STEP_SUMMARY
               echo "Apply Cache workflow required but failed. No build will run." >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "Please run the 03 Maintain: Apply Package Cache manually to build a valid renv cache." >> $GITHUB_STEP_SUMMARY
               echo "push_or_pr=false" >> $GITHUB_OUTPUT
               exit 1
             else


### PR DESCRIPTION
This PR removes the "silent" failure from the build preflight action when an renv cache is required but a previous cache application step fails (I'm thinking as a result of a read-only cache attempt: https://github.blog/changelog/2026-06-26-read-only-actions-cache-for-untrusted-triggers/)
