### PR TITLE
Await diff file stat before reading

### DIFF
--- a/comment-diff/index.js
+++ b/comment-diff/index.js
@@ -17,14 +17,13 @@ async function run() {
 
 
   if (path) {
-    fs.stat(path, function(err, stat) {
-      if (err == null) {
-        body = String(fs.readFileSync(path));
-      } else {
-        core.setFailed(`File Error: ${err.code}`);
-        process.exit(1);
-      }
-    });
+    try {
+      await fs.promises.stat(path);
+      body = String(await fs.promises.readFile(path));
+    } catch (err) {
+      core.setFailed(`File Error: ${err.code}`);
+      process.exit(1);
+    }
   } else {
     body = core.getInput('body');
   }


### PR DESCRIPTION
I think there is a persistent yet intermittent race condition with reading the diff.md unzipped before commenting on the PR with the diff'ed changes.

This PR adds in an await to block until the file gets read.
